### PR TITLE
SC-8: `reusable-nodejs-test` workflow 추가

### DIFF
--- a/.github/workflows/reusable-nodejs-test.yml
+++ b/.github/workflows/reusable-nodejs-test.yml
@@ -31,14 +31,14 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
-      - name: Install dependencies with NPM
-        if: ${{ inputs.package-manager == 'npm' }}
-        run: npm ci
-      - name: Install dependencies with Yarn
-        if: ${{ inputs.package-manager == 'yarn' }}
-        run: yarn install --immutable
-      - name: Install dependencies with Yarn Legacy
-        if: ${{ inputs.package-manager == 'yarn-legacy' }}
-        run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: |
+          if [[ "${{ inputs.package-manager == 'npm' }}" == "true" ]]; then
+            npm ci
+          elif [[ "${{ inputs.package-manager == 'yarn' }}" == "true" ]]; then
+            yarn install --immutable
+          elif [[ "${{ inputs.package-manager == 'yarn-legacy' }}" == "true" ]]; then
+            yarn install --frozen-lockfile
+          fi
       - name: Run the test
         run: ${{ inputs.package-manager }} ${{ inputs.test-command }} ${{ inputs.test-command-args }}

--- a/.github/workflows/reusable-nodejs-test.yml
+++ b/.github/workflows/reusable-nodejs-test.yml
@@ -1,0 +1,44 @@
+name: "Node.js Test"
+
+on:
+  workflow_call:
+    inputs:
+      package-manager:
+        description: "Specifies which package manager to be used"
+        required: false
+        default: 'yarn'
+        type: string
+      test-command:
+        description: "Specifies a test command that will be passed to the package manager"
+        required: false
+        default: 'test'
+        type: string
+      test-command-args:
+        description: "Specifies an optional arguments to the test command"
+        required: false
+        default: ''
+        type: string
+
+env:
+  NODE_ENV: development # This must always be set. Otherwise, required dependencies to run test will not be installed or inconsistency happens.
+  CI: true
+
+jobs:
+  run-test:
+    if: ${{ inputs.package-manager == 'yarn' }}
+    name: Run Node.js test
+    runs-on: [self-hosted, Linux, X64, cache, node-16]
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+      - name: Install dependencies with NPM
+        if: ${{ inputs.package-manager == 'npm' }}
+        run: npm ci
+      - name: Install dependencies with Yarn
+        if: ${{ inputs.package-manager == 'yarn' }}
+        run: yarn install --immutable
+      - name: Install dependencies with Yarn Legacy
+        if: ${{ inputs.package-manager == 'yarn-legacy' }}
+        run: yarn install --frozen-lockfile
+      - name: Run the test
+        run: ${{ inputs.package-manager }} ${{ inputs.test-command }} ${{ inputs.test-command-args }}

--- a/.github/workflows/reusable-nodejs-test.yml
+++ b/.github/workflows/reusable-nodejs-test.yml
@@ -29,7 +29,7 @@ jobs:
     name: Run Node.js test
     runs-on: [self-hosted, Linux, X64, cache, node-16]
     steps:
-      - name: Check out the code
+      - name: Check out code
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
@@ -40,5 +40,5 @@ jobs:
           elif [[ "${{ inputs.package-manager == 'yarn-legacy' }}" == "true" ]]; then
             yarn install --frozen-lockfile
           fi
-      - name: Run the test
+      - name: Run test
         run: ${{ inputs.package-manager }} ${{ inputs.test-command }} ${{ inputs.test-command-args }}


### PR DESCRIPTION
- `reusable-nodejs-test` workflow를 추가합니다.

## Ticket Reference

- [SC-8](https://ohouse.atlassian.net/browse/SC-8)

## Description

- 재사용할 수 있는 Node.js 테스트 workflow를 추가합니다.

## Usage

프로젝트에 다음과 같이 사용할 수 있습니다:

> PR이 열릴 때마다 test 돌려주는 workflow 예제:
```yml
name: Node.js Test

on:
  - pull_request

jobs:
  test:
    uses: bucketplace/ci/.github/workflows/reusable-nodejs-test.yml@main
    # 따로 옵션을 주지 않으면 Yarn v2+ 기준으로 동작합니다.
    with:
      package-manager: npm # npm, yarn, yarn-legacy 선택 가능
      test-command: custom-test # test 커맨드 명을 바꾸고 싶을 때 사용, 일반적으로 변경을 권장하지 않음
      test-command-args: '--foobar' # test 커맨드에 전달할 옵션
```

**Note:** excerpted from https://github.com/bp-operator/github-action-ci-workflows/pull/1