### PR TITLE
[COREPL-183] go package deploy ci

### DIFF
--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -42,12 +42,15 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, cache]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Lint
         uses: reviewdog/action-golangci-lint@v2
+        env:                                                                    
+          GOPROXY: "https://go.co-workerhou.se,https://proxy.golang.org,direct"
+          GONOSUMDB: "go.dailyhou.se"
         with:
           reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]
           go_version: ${{ inputs.go-version }}

--- a/.github/workflows/deploy-go-package.yml
+++ b/.github/workflows/deploy-go-package.yml
@@ -49,7 +49,7 @@ jobs:
           export PATH=$(go env GOPATH)/bin:$PATH && \
           pack --module-name="${{ inputs.package-name }}" \
             --module-root-path="${{ inputs.package-path }}" \
-            --module-version="v${{ inputs.package-version }}" \
+            --module-version="${{ inputs.package-version }}" \
             --aws-access-key-id="${{ secrets.AWS_ACCESS_KEY_ID }}" \
             --aws-secret-access-key="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
       

--- a/.github/workflows/deploy-go-package.yml
+++ b/.github/workflows/deploy-go-package.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           cache: true
-          cache-dependency-path: ${{ inputs.app-path }}/go.sum
+          cache-dependency-path: ${{ inputs.package-path }}/go.sum
           go-version: ${{ inputs.go-version }}
       - name: Setup Environment
         run: |

--- a/.github/workflows/deploy-go-package.yml
+++ b/.github/workflows/deploy-go-package.yml
@@ -1,0 +1,67 @@
+name: "Deploy Go Package"
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        type: string
+        description: "배포될 패키지의 앱 이름 (ex. go.dailyhou.se/gohouse/pack)"
+        required: true
+      package-version:
+        type: string
+        description: 패키지 배포 버전
+        required: true
+      package-path:
+        type: string
+        description: "레포지토리 기준 패키지 루트 디렉토리 디렉토리"
+        required: false
+        default: "."
+      go-version:
+        type: string
+        description: go 버전
+        required: false
+        default: "1.18"
+    secrets:
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+jobs:
+  lint:
+    name: Deploy
+    runs-on: [self-hosted, Linux, X64, cache]
+    steps:        
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          cache: true
+          cache-dependency-path: ${{ inputs.app-path }}/go.sum
+          go-version: ${{ inputs.go-version }}
+      - name: Setup Environment
+        run: |
+          go env -w GOPROXY=https://go.co-workerhou.se,https://proxy.golang.org,direct && \
+          go env -w GONOSUMDB=go.dailyhou.se && \
+          go install go.dailyhou.se/gohouse/pack/cmd/pack@v0.2.0
+      - name: Deploy Package
+        run: |
+          export PATH=$(go env GOPATH)/bin:$PATH && \
+          pack --module-name="${{ inputs.package-name }}" \
+            --module-root-path="${{ inputs.package-path }}" \
+            --module-version="v${{ inputs.package-version }}" \
+            --aws-access-key-id="${{ secrets.AWS_ACCESS_KEY_ID }}" \
+            --aws-secret-access-key="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+      
+      - name: Add Summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Request Information
+          | Name | Details |
+          | --- | --- |
+          | Package Name | ${{ inputs.package-name }} |
+          | Package Version | ${{ inputs.package-version }} |
+          | App Path | ${{ inputs.package-path }} |
+          | Go Version | ${{ inputs.go-version}} |
+          | Deployed By | @${{ github.actor }} |
+          EOF


### PR DESCRIPTION
## Proposed Changes
- go package를 배포해주는 CI를 만들었습니다.
- Lint 과정에서 Typecheck가 컴파일할 때 패키지를 못 찾는 문제가 생기지 않게 합니다.

## Test Status
- Lint 과정에서 컴파일 실패로 인한 패싱 문제 해결
  - [기존 상태](https://github.com/bucketplace/feature-flag/actions/runs/3692551023/jobs/6251558371)
  ```console
  /home/runner/work/_temp/reviewdog-fGvb9l/golangci-lint-1.50.1-linux-amd64/golangci-lint run --out-format line-number --config=.golangci.yaml ./...
  level=warning msg="[runner] Can't run linter goanalysis_metalinter: inspect: failed to load package : could not load export data: no export data for \"go.dailyhou.se/gohouse/errors\""
  level=error msg="Running error: 1 error occurred:\n\t* can't run linter goanalysis_metalinter: inspect: failed to load package : could not load export data: no export data for \"go.dailyhou.se/gohouse/errors\"\n\n"
  /home/runner/work/_temp/reviewdog-fGvb9l/reviewdog -f=golangci-lint -name=golangci -reporter=github-pr-check -filter-mode=nofilter -fail-on-error=true -level=error
  2022/12/14 07:06:59 [golangci] reported: https://github.com/bucketplace/feature-flag/runs/100[83](https://github.com/bucketplace/feature-flag/actions/runs/3692551023/jobs/6251558371#step:3:88)001966 (conclusion=success)
  ```
  - [수정 상태](https://github.com/bucketplace/feature-flag/actions/runs/3822245099/jobs/6502184829)

- [Deploy 시도 예시](https://github.com/bucketplace/gohouse/actions/runs/3826969790)
