### PR TITLE
fix: PR이 아닐 때 "Add Result To Summary"step을 실행하지 않는다

### DIFF
--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -158,7 +158,7 @@ jobs:
             -Dsonar.exclusions=${{ inputs.sonar-exclusions }}
             ${{ steps.sonarqube-params.outputs.sonarParameters }}
       - name: Add Result To Summary
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         run: |
           cat code-coverage-results.md >> result.md
           echo "" >> result.md


### PR DESCRIPTION
## Proposed Changes
PR이 아닐 때 "Create Coverage Information"이랑 "Add Report To PR" skip 되서 "Add Result To Summary"를 실행하면 실페됩니다.
오류: "cat: code-coverage-results.md: No such file or directory"




## Test Status
(테스트를 어떻게 진행했는지 설명합니다.)
