### PR TITLE
SC-59: FE release workflow 공통 GitHub workflows/actions 추가

### DIFF
--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -82,3 +82,7 @@ runs:
         echo "install-cmd=${INSTALL_CMD}" >> $GITHUB_OUTPUT
         echo "exec-cmd=${EXEC_CMD}" >> $GITHUB_OUTPUT
         echo "run-cmd=${RUN_CMD}" >> $GITHUB_OUTPUT
+        # Setting environment variables for convenience when accessing commands
+        echo "PKG_CMD_INSTALL=${INSTALL_CMD}" >> $GITHUB_ENV
+        echo "PKG_CMD_EXEC=${EXEC_CMD}" >> $GITHUB_ENV
+        echo "PKG_CMD_RUN=${RUN_CMD}" >> $GITHUB_ENV

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -2,6 +2,11 @@ name: "Select Node.js Package Manager"
 description: "Selects a package manager to use by running resolution logic"
 
 inputs:
+  app-path:
+    description: "Specifies a base directory to run the task from"
+    required: false
+    default: '.'
+    type: string
   package-manager:
     description: "Specifies which package manager to use"
     required: false
@@ -32,13 +37,13 @@ runs:
         # Try to infer which package manager currently in use if not specified
         NODEJS_PACKAGE_MANAGER="${{ inputs.package-manager }}"
         if [[ "${NODEJS_PACKAGE_MANAGER}" == "" ]]; then
-          if [[ -f "yarn.lock" ]]; then
-            if [[ -d ".yarn/" ]]; then
+          if [[ -f "${{ inputs.app-path }}/yarn.lock" ]]; then
+            if [[ -d "${{ inputs.app-path }}/.yarn/" ]]; then
               NODEJS_PACKAGE_MANAGER="yarn"
             else
               NODEJS_PACKAGE_MANAGER="yarn-legacy"
             fi
-          elif [[ -f "pnpm-lock.yaml" ]]; then
+          elif [[ -f "${{ inputs.app-path }}/pnpm-lock.yaml" ]]; then
             NODEJS_PACKAGE_MANAGER="pnpm"
           else
             NODEJS_PACKAGE_MANAGER="npm"

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -36,6 +36,7 @@ runs:
       run: |
         # Try to infer which package manager currently in use if not specified
         NODEJS_PACKAGE_MANAGER="${{ inputs.package-manager }}"
+        echo "current dir: $(pwd)"
         if [[ "${NODEJS_PACKAGE_MANAGER}" == "" ]]; then
           if [[ -f "${{ inputs.app-path }}/yarn.lock" ]]; then
             if [[ -d "${{ inputs.app-path }}/.yarn/" ]]; then

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -36,7 +36,6 @@ runs:
       run: |
         # Try to infer which package manager currently in use if not specified
         NODEJS_PACKAGE_MANAGER="${{ inputs.package-manager }}"
-        echo "current dir: $(pwd)"
         if [[ "${NODEJS_PACKAGE_MANAGER}" == "" ]]; then
           if [[ -f "${{ inputs.app-path }}/yarn.lock" ]]; then
             if [[ -d "${{ inputs.app-path }}/.yarn/" ]]; then

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -61,7 +61,7 @@ runs:
           yarn-legacy)
             PKG_BIN="yarn"
             INSTALL_CMD="yarn install --frozen-lockfile"
-            EXEC_CMD="yarn run"
+            EXEC_CMD="npm exec --" # Yarn Legacy doesn't have exec command, so borrowing it from npm here
             RUN_CMD="yarn run"
             ;;
           pnpm)

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -37,6 +37,7 @@ runs:
         # Try to infer which package manager currently in use if not specified
         NODEJS_PACKAGE_MANAGER="${{ inputs.package-manager }}"
         echo "current dir: $(pwd)"
+        ls -lAFh
         if [[ "${NODEJS_PACKAGE_MANAGER}" == "" ]]; then
           if [[ -f "${{ inputs.app-path }}/yarn.lock" ]]; then
             if [[ -d "${{ inputs.app-path }}/.yarn/" ]]; then

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -87,7 +87,3 @@ runs:
         echo "install-cmd=${INSTALL_CMD}" >> $GITHUB_OUTPUT
         echo "exec-cmd=${EXEC_CMD}" >> $GITHUB_OUTPUT
         echo "run-cmd=${RUN_CMD}" >> $GITHUB_OUTPUT
-        # Setting environment variables for convenience when accessing commands
-        echo "PKG_CMD_INSTALL=${INSTALL_CMD}" >> $GITHUB_ENV
-        echo "PKG_CMD_EXEC=${EXEC_CMD}" >> $GITHUB_ENV
-        echo "PKG_CMD_RUN=${RUN_CMD}" >> $GITHUB_ENV

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -1,0 +1,68 @@
+name: "Select Node.js Package Manager"
+description: "Selects a package manager to use by running resolution logic"
+
+inputs:
+  package-manager:
+    description: "Specifies which package manager to use"
+    required: false
+    default: ""
+    type: string
+
+outputs:
+  pkg-bin:
+    description: "The package manager binary name"
+    value: ${{ steps.determine-package-manager.outputs.pkg-bin }}
+  install-command:
+    description: "A command that can be used to install Node.js modules in CI mode"
+    value: ${{ steps.determine-package-manager.outputs.install-command }}
+
+runs:
+  using: composite
+  steps:
+    - name: Determine which package manager to use
+      id: determine-package-manager
+      shell: bash
+      run: |
+        # Try to infer which package manager currently in use if not specified
+        NODEJS_PACKAGE_MANAGER="${{ inputs.package-manager }}"
+        if [[ "${NODEJS_PACKAGE_MANAGER}" == "" ]]; then
+          if [[ -f "yarn.lock" ]]; then
+            if [[ -d ".yarn/" ]]; then
+              NODEJS_PACKAGE_MANAGER="yarn"
+            else
+              NODEJS_PACKAGE_MANAGER="yarn-legacy"
+            fi
+          elif [[ -f "pnpm-lock.yaml" ]]; then
+            NODEJS_PACKAGE_MANAGER="pnpm"
+          else
+            NODEJS_PACKAGE_MANAGER="npm"
+          fi
+        fi
+        # Prepare outputs
+        case $NODEJS_PACKAGE_MANAGER in
+          npm)
+            PKG_BIN="npm"
+            INSTALL_CMD="npm ci"
+            ;;
+          yarn)
+            PKG_BIN="yarn"
+            INSTALL_CMD="yarn install --immutable"
+            ;;
+          yarn-legacy)
+            PKG_BIN="yarn"
+            INSTALL_CMD="yarn install --frozen-lockfile"
+            ;;
+          pnpm)
+            PKG_BIN="pnpm"
+            INSTALL_CMD="pnpm install --frozen-lockfile"
+            ;;
+          *)
+            echo "Unknown package manager type"
+            exit 1
+            ;;
+        esac
+        # Print outputs
+        echo "Using package manager: ${PKG_BIN}"
+        echo "pkg-bin=${PKG_BIN}" >> $GITHUB_OUTPUT
+        echo "Using install command: ${INSTALL_CMD}"
+        echo "install-command=${INSTALL_CMD}" >> $GITHUB_OUTPUT

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -37,7 +37,6 @@ runs:
         # Try to infer which package manager currently in use if not specified
         NODEJS_PACKAGE_MANAGER="${{ inputs.package-manager }}"
         echo "current dir: $(pwd)"
-        ls -lAFh
         if [[ "${NODEJS_PACKAGE_MANAGER}" == "" ]]; then
           if [[ -f "${{ inputs.app-path }}/yarn.lock" ]]; then
             if [[ -d "${{ inputs.app-path }}/.yarn/" ]]; then

--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -9,12 +9,18 @@ inputs:
     type: string
 
 outputs:
-  pkg-bin:
+  bin:
     description: "The package manager binary name"
-    value: ${{ steps.determine-package-manager.outputs.pkg-bin }}
-  install-command:
+    value: ${{ steps.determine-package-manager.outputs.bin }}
+  install-cmd:
     description: "A command that can be used to install Node.js modules in CI mode"
     value: ${{ steps.determine-package-manager.outputs.install-command }}
+  exec-cmd:
+    description: "A command prefix that can be used to execute bin modules in node_modules/.bin"
+    value: ${{ steps.determine-package-manager.outputs.exec-cmd }}
+  run-cmd:
+    description: "A command prefix that can be used to run scripts in package.json"
+    value: ${{ steps.determine-package-manager.outputs.run-command }}
 
 runs:
   using: composite
@@ -38,31 +44,41 @@ runs:
             NODEJS_PACKAGE_MANAGER="npm"
           fi
         fi
-        # Prepare outputs
+        # Prepares for outputs
         case $NODEJS_PACKAGE_MANAGER in
           npm)
             PKG_BIN="npm"
             INSTALL_CMD="npm ci"
+            EXEC_CMD="npm exec --"
+            RUN_CMD="npm run"
             ;;
           yarn)
             PKG_BIN="yarn"
             INSTALL_CMD="yarn install --immutable"
+            EXEC_CMD="yarn exec"
+            RUN_CMD="yarn run"
             ;;
           yarn-legacy)
             PKG_BIN="yarn"
             INSTALL_CMD="yarn install --frozen-lockfile"
+            EXEC_CMD="yarn run"
+            RUN_CMD="yarn run"
             ;;
           pnpm)
             PKG_BIN="pnpm"
             INSTALL_CMD="pnpm install --frozen-lockfile"
+            EXEC_CMD="pnpm exec"
+            RUN_CMD="pnpm run"
             ;;
           *)
             echo "Unknown package manager type"
             exit 1
             ;;
         esac
-        # Print outputs
+        # Prints the outputs
         echo "Using package manager: ${PKG_BIN}"
-        echo "pkg-bin=${PKG_BIN}" >> $GITHUB_OUTPUT
-        echo "Using install command: ${INSTALL_CMD}"
-        echo "install-command=${INSTALL_CMD}" >> $GITHUB_OUTPUT
+        # Setting output variables
+        echo "bin=${PKG_BIN}" >> $GITHUB_OUTPUT
+        echo "install-cmd=${INSTALL_CMD}" >> $GITHUB_OUTPUT
+        echo "exec-cmd=${EXEC_CMD}" >> $GITHUB_OUTPUT
+        echo "run-cmd=${RUN_CMD}" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-nodejs.yml
+++ b/.github/workflows/check-nodejs.yml
@@ -6,7 +6,7 @@ on:
       app-path:
         description: "Specifies a base directory to run the task from"
         required: false
-        default: './'
+        default: '.'
         type: string
       nodejs-version:
         description: "Specifies which Node.js version to use"
@@ -49,6 +49,7 @@ jobs:
         id: package-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
+          app-path: ${{ inputs.app-path }}
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
         run: ${{ steps.package-manager.outputs.install-command }}

--- a/.github/workflows/check-nodejs.yml
+++ b/.github/workflows/check-nodejs.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use
-        id: package-manager
+        id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
           app-path: ${{ inputs.app-path }}
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
-        run: ${{ steps.package-manager.outputs.install-command }}
+        run: ${{ steps.pkg-manager.outputs.install-cmd }}
       - name: Run test
-        run: ${{ steps.package-manager.outputs.bin }} run ${{ inputs.test-command }} ${{ inputs.test-command-args }}
+        run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.test-command }} ${{ inputs.test-command-args }}

--- a/.github/workflows/check-nodejs.yml
+++ b/.github/workflows/check-nodejs.yml
@@ -47,45 +47,10 @@ jobs:
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use
         id: package-manager
-        run: |
-          PACKAGE_MANAGER="${{ inputs.package-manager }}"
-          # Try to infer which package manager currently in use if not specified
-          if [[ "${PACKAGE_MANAGER}" == "" ]]; then
-            if [[ -f "yarn.lock" ]]; then
-              if [[ -d ".yarn/" ]]; then
-                PACKAGE_MANAGER="yarn"
-              else
-                PACKAGE_MANAGER="yarn-legacy"
-              fi
-            else
-              PACKAGE_MANAGER="npm"
-            fi
-          fi
-          # Prepare outputs
-          case $PACKAGE_MANAGER in
-            npm)
-              PKG_BIN="npm"
-              INSTALL_CMD="npm ci"
-              ;;
-            yarn)
-              PKG_BIN="yarn"
-              INSTALL_CMD="yarn install --immutable"
-              ;;
-            yarn-legacy)
-              PKG_BIN="yarn"
-              INSTALL_CMD="yarn install --frozen-lockfile"
-              ;;
-            *)
-              echo "Unknown package manager type"
-              exit 1
-              ;;
-          esac
-          # Print outputs
-          echo "Using the package manager: ${PKG_BIN}"
-          echo "bin=${PKG_BIN}" >> $GITHUB_OUTPUT
-          echo "Using the install command: ${INSTALL_CMD}"
-          echo "install-command=${INSTALL_CMD}" >> $GITHUB_OUTPUT
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
+        with:
+          package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
         run: ${{ steps.package-manager.outputs.install-command }}
       - name: Run test
-        run: ${{ steps.package-manager.outputs.bin }} ${{ inputs.test-command }} ${{ inputs.test-command-args }}
+        run: ${{ steps.package-manager.outputs.bin }} run ${{ inputs.test-command }} ${{ inputs.test-command-args }}

--- a/.github/workflows/check-nodejs.yml
+++ b/.github/workflows/check-nodejs.yml
@@ -9,7 +9,7 @@ on:
         default: './'
         type: string
       nodejs-version:
-        description: "Specifies what Node.js version to use"
+        description: "Specifies which Node.js version to use"
         required: false
         default: '16'
         type: string

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -29,9 +29,6 @@ on:
         default: 'pre'
         type: string
     secrets:
-      GITHUB_TOKEN:
-        description: "GitHub's default token for the current repository"
-        required: true
       NEXUS_NPM_TOKEN:
         description: "A Nexus NPM token for publishing packages"
         required: true

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use
         id: pkg-manager
-        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@feature/SC-59
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -34,7 +34,7 @@ env:
   CI: true
 
 jobs:
-  publish:
+  prerelease:
     name: Run Changesets prerelease
     runs-on: [self-hosted, Linux, X64, cache, node-16]
     defaults:

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -62,17 +62,17 @@ jobs:
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
-        run: ${{ env.PKG_CMD_INSTALL }}
+        run: ${{ steps.pkg-manager.outputs.install-cmd }}
       - name: Enter prerelease Mode
-        run: ${{ env.PKG_CMD_EXEC }} changeset pre enter ${{ inputs.prerelease-tag }}
+        run: ${{ steps.pkg-manager.outputs.exec-cmd }} changeset pre enter ${{ inputs.prerelease-tag }}
       - name: Bump version for prerelease
-        run: ${{ env.PKG_CMD_EXEC }} changeset version
+        run: ${{ steps.pkg-manager.outputs.exec-cmd }} changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build packages
-        run: ${{ env.PKG_CMD_RUN }} ${{ inputs.build-command }}
+        run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.build-command }}
       - name: Publish prerelease version
-        run: ${{ env.PKG_CMD_EXEC }} changeset publish
+        run: ${{ steps.pkg-manager.outputs.exec-cmd }} changeset publish
       - name: Commit
         uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
         with:

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -28,6 +28,13 @@ on:
         required: false
         default: 'pre'
         type: string
+    secrets:
+      GITHUB_TOKEN:
+        description: "GitHub's default token for the current repository"
+        required: true
+      NEXUS_NPM_TOKEN:
+        description: "A Nexus NPM token for publishing packages"
+        required: true
 
 env:
   NODE_ENV: production

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   publish:
-    name: Run Changesets Prerelease
+    name: Run Changesets prerelease
     runs-on: [self-hosted, Linux, X64, cache, node-16]
     defaults:
       run:
@@ -50,15 +50,15 @@ jobs:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
         run: ${{ env.PKG_CMD_INSTALL }}
-      - name: Enter Prerelease Mode
+      - name: Enter prerelease Mode
         run: ${{ env.PKG_CMD_EXEC }} changeset pre enter ${{ inputs.prerelease-tag }}
-      - name: Bump version for Prerelease
+      - name: Bump version for prerelease
         run: ${{ env.PKG_CMD_EXEC }} changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build packages
         run: ${{ env.PKG_CMD_RUN }} ${{ inputs.build-command }}
-      - name: Publish Prerelease version
+      - name: Publish prerelease version
         run: ${{ env.PKG_CMD_EXEC }} changeset publish
       - name: Commit
         uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -41,6 +41,8 @@ jobs:
       run:
         working-directory: ${{ inputs.app-path }}
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -45,6 +45,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+      - name: Configure registry
+        run: |
+          cat <<EOF > "$HOME/.npmrc"
+            //nexus.co-workerhou.se/repository/npm-private/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
       - name: Determine which package manager to use
         id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@feature/SC-59

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -1,4 +1,5 @@
 name: "Prerelease Packages"
+
 on:
   workflow_call:
     inputs:
@@ -27,6 +28,7 @@ on:
         required: false
         default: 'pre'
         type: string
+
 env:
   NODE_ENV: production
   CI: true

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -6,7 +6,7 @@ on:
       app-path:
         description: "Specifies a base directory to run the task from"
         required: false
-        default: './'
+        default: '.'
         type: string
       nodejs-version:
         description: "Specifies which Node.js version to use"

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -58,7 +58,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
       - name: Determine which package manager to use
         id: pkg-manager
-        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@feature/SC-59
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -42,27 +42,22 @@ jobs:
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use
-        id: package-manager
+        id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
-        run: ${{ steps.package-manager.outputs.install-command }}
-
+        run: ${{ env.PKG_CMD_INSTALL }}
       - name: Enter Prerelease Mode
-        run: yarn changeset pre enter ${{ inputs.prerelease-tag }}
-
+        run: ${{ env.PKG_CMD_EXEC }} changeset pre enter ${{ inputs.prerelease-tag }}
       - name: Bump version for Prerelease
-        run: yarn changeset version
+        run: ${{ env.PKG_CMD_EXEC }} changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build packages
-        run: yarn ${{ inputs.build-command }}
-
+        run: ${{ env.PKG_CMD_RUN }} ${{ inputs.build-command }}
       - name: Publish Prerelease version
-        run: yarn changeset publish
-
+        run: ${{ env.PKG_CMD_EXEC }} changeset publish
       - name: Commit
         uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
         with:

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -1,0 +1,72 @@
+name: "Prerelease Packages"
+on:
+  workflow_call:
+    inputs:
+      app-path:
+        description: "Specifies a base directory to run the task from"
+        required: false
+        default: './'
+        type: string
+      nodejs-version:
+        description: "Specifies which Node.js version to use"
+        required: false
+        default: '16'
+        type: string
+      package-manager:
+        description: "Specifies which package manager to use"
+        required: false
+        default: ''
+        type: string
+      build-command:
+        description: "Specifies a build command used on package finalizing before publish"
+        required: false
+        default: 'build'
+        type: string
+      prerelease-tag:
+        description: "Specifies a tag name that is used for prerelease mode"
+        required: false
+        default: 'pre'
+        type: string
+env:
+  NODE_ENV: production
+  CI: true
+
+jobs:
+  publish:
+    name: Run Changesets Prerelease
+    runs-on: [self-hosted, Linux, X64, cache, node-16]
+    defaults:
+      run:
+        working-directory: ${{ inputs.app-path }}
+    steps:
+      - name: Use Node.js ${{ inputs.nodejs-version }}
+        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+      - name: Determine which package manager to use
+        id: package-manager
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
+        with:
+          package-manager: ${{ inputs.package-manager }}
+      - name: Install dependencies
+        run: ${{ steps.package-manager.outputs.install-command }}
+
+      - name: Enter Prerelease Mode
+        run: yarn changeset pre enter ${{ inputs.prerelease-tag }}
+
+      - name: Bump version for Prerelease
+        run: yarn changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build packages
+        run: yarn ${{ inputs.build-command }}
+
+      - name: Publish Prerelease version
+        run: yarn changeset publish
+
+      - name: Commit
+        uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
+        with:
+          add: '.'
+          committer_name: bp-deployer
+          committer_email: bp-deployer@users.noreply.github.com
+          message: '[skip actions] Prerelease ${{inputs.prerelease-tag}}'

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -49,6 +49,8 @@ jobs:
         run: ${{ steps.package-manager.outputs.install-command }}
       - name: Build packages
         run: yarn build
+      - name: Try to exit Changesets prerelease mode
+        uses: yarn changeset pre exit
       - name: Publish package
         uses: changesets/action@v1
         with:

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -47,7 +47,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
       - name: Determine which package manager to use
         id: pkg-manager
-        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@feature/SC-59
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -24,9 +24,6 @@ on:
         default: 'build'
         type: string
     secrets:
-      GITHUB_TOKEN:
-        description: "GitHub's default token for the current repository"
-        required: true
       NEXUS_NPM_TOKEN:
         description: "A Nexus NPM token for publishing packages"
         required: true

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -36,6 +36,8 @@ jobs:
       run:
         working-directory: ${{ inputs.app-path }}
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Configure registry

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -53,7 +53,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
       - name: Determine which package manager to use
         id: pkg-manager
-        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@feature/SC-59
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -46,19 +46,19 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
       - name: Determine which package manager to use
-        id: package-manager
+        id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
-        run: ${{ steps.package-manager.outputs.install-command }}
+        run: ${{ env.PKG_CMD_INSTALL }}
       - name: Build packages
-        run: yarn run ${{ inputs.build-command }}
+        run: ${{ env.PKG_CMD_RUN }} ${{ inputs.build-command }}
       - name: Try to exit Changesets prerelease mode
-        uses: yarn changeset pre exit
+        uses: ${{ env.PKG_CMD_EXEC }} changeset pre exit
       - name: Publish package
         uses: changesets/action@v1
         with:
-          publish: yarn changeset publish
+          publish: ${{ env.PKG_CMD_EXEC }} changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -27,6 +27,9 @@ jobs:
   publish:
     name: Run Changesets publish
     runs-on: [self-hosted, Linux, X64, cache, node-16]
+    defaults:
+      run:
+        working-directory: ${{ inputs.app-path }}
     steps:
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -33,6 +33,13 @@ jobs:
     steps:
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+      - name: Configure registry
+        run: |
+          cat <<EOF > "$HOME/.npmrc"
+            //nexus.co-workerhou.se/repository/npm-private/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
       - name: Determine which package manager to use
         id: package-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
@@ -40,3 +47,11 @@ jobs:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
         run: ${{ steps.package-manager.outputs.install-command }}
+      - name: Build packages
+        run: yarn build
+      - name: Publish package
+        uses: changesets/action@v1
+        with:
+          publish: yarn changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -23,6 +23,13 @@ on:
         required: false
         default: 'build'
         type: string
+    secrets:
+      GITHUB_TOKEN:
+        description: "GitHub's default token for the current repository"
+        required: true
+      NEXUS_NPM_TOKEN:
+        description: "A Nexus NPM token for publishing packages"
+        required: true
 
 env:
   NODE_ENV: production

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -6,7 +6,7 @@ on:
       app-path:
         description: "Specifies a base directory to run the task from"
         required: false
-        default: './'
+        default: '.'
         type: string
       nodejs-version:
         description: "Specifies which Node.js version to use"

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -1,0 +1,39 @@
+name: "Publish Packages"
+
+on:
+  workflow_call:
+    inputs:
+      app-path:
+        description: "Specifies a base directory to run the task from"
+        required: false
+        default: './'
+        type: string
+      nodejs-version:
+        description: "Specifies which Node.js version to use"
+        required: false
+        default: '16'
+        type: string
+      package-manager:
+        description: "Specifies which package manager to use"
+        required: false
+        default: ''
+        type: string
+
+env:
+  NODE_ENV: production
+  CI: true
+
+jobs:
+  publish:
+    name: Run Changesets publish
+    runs-on: [self-hosted, Linux, X64, cache, node-16]
+    steps:
+      - name: Use Node.js ${{ inputs.nodejs-version }}
+        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+      - name: Determine which package manager to use
+        id: package-manager
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
+        with:
+          package-manager: ${{ inputs.package-manager }}
+      - name: Install dependencies
+        run: ${{ steps.package-manager.outputs.install-command }}

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -57,14 +57,14 @@ jobs:
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
-        run: ${{ env.PKG_CMD_INSTALL }}
+        run: ${{ steps.pkg-manager.outputs.install-cmd }}
       - name: Build packages
-        run: ${{ env.PKG_CMD_RUN }} ${{ inputs.build-command }}
+        run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.build-command }}
       - name: Try to exit Changesets prerelease mode
-        uses: ${{ env.PKG_CMD_EXEC }} changeset pre exit
+        uses: ${{ steps.pkg-manager.outputs.exec-cmd }} changeset pre exit
       - name: Publish package
         uses: changesets/action@v1
         with:
-          publish: ${{ env.PKG_CMD_EXEC }} changeset publish
+          publish: ${{ steps.pkg-manager.outputs.exec-cmd }} changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ''
         type: string
+      build-command:
+        description: "Specifies a build command used on package finalizing before publish"
+        required: false
+        default: 'build'
+        type: string
 
 env:
   NODE_ENV: production
@@ -48,7 +53,7 @@ jobs:
       - name: Install dependencies
         run: ${{ steps.package-manager.outputs.install-command }}
       - name: Build packages
-        run: yarn build
+        run: yarn run ${{ inputs.build-command }}
       - name: Try to exit Changesets prerelease mode
         uses: yarn changeset pre exit
       - name: Publish package

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use
         id: pkg-manager
-        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@feature/SC-59
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -1,0 +1,81 @@
+name: "Prerelease Packages"
+on:
+  issue_comment:
+    types: [ created ]
+  workflow_call:
+    inputs:
+      app-path:
+        description: "Specifies a base directory to run the task from"
+        required: false
+        default: './'
+        type: string
+      nodejs-version:
+        description: "Specifies which Node.js version to use"
+        required: false
+        default: '16'
+        type: string
+      package-manager:
+        description: "Specifies which package manager to use"
+        required: false
+        default: ''
+        type: string
+      build-command:
+        description: "Specifies a build command used on package finalizing before publish"
+        required: false
+        default: 'build'
+        type: string
+      snapshot-tag:
+        description: "Specifies a tag name that is used for snapshot release"
+        required: false
+        default: 'snap'
+        type: string
+
+env:
+  NODE_ENV: production
+  CI: true
+
+jobs:
+  check-comment:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    outputs:
+      triggered: ${{ steps.check.outputs.triggered }}
+      extra_args: ${{ steps.check.outputs.extra_args }}
+    steps:
+      - uses: bucketplace/comment-trigger@v1.0
+        id: check
+        with:
+          trigger: '/snapshot'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Run Changesets Pre release
+    runs-on: [self-hosted, Linux, X64, cache, node-16]
+    needs: check-comment
+    defaults:
+      run:
+        working-directory: ${{ inputs.app-path }}
+    steps:
+      - name: Use Node.js ${{ inputs.nodejs-version }}
+        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+      - name: Determine which package manager to use
+        id: package-manager
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
+        with:
+          package-manager: ${{ inputs.package-manager }}
+      - name: Install dependencies
+        run: ${{ steps.package-manager.outputs.install-command }}
+
+      - name: Build packages
+        run: yarn ${{ inputs.build-command }}
+
+      - name: Change version for snapshot
+        run: yarn changeset version --snapshot ${{ inputs.snapshot-tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Snapshot
+        run: yarn changeset publish --tag ${{ inputs.snapshot-tag }} --snapshot --no-git-tag
+

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -48,9 +48,8 @@ jobs:
           reaction: rocket
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish:
-    name: Run Changesets Pre release
+    name: Run Changesets prerelease
     runs-on: [self-hosted, Linux, X64, cache, node-16]
     needs: check-comment
     defaults:
@@ -72,5 +71,5 @@ jobs:
         run: ${{ env.PKG_CMD_EXEC }} changeset version --snapshot ${{ inputs.snapshot-tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish Snapshot
+      - name: Publish snapshot
         run: ${{ env.PKG_CMD_EXEC }} changeset publish --tag ${{ inputs.snapshot-tag }} --snapshot --no-git-tag

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -1,7 +1,6 @@
-name: "Prerelease Packages"
+name: "Snapshot Packages"
+
 on:
-  issue_comment:
-    types: [ created ]
   workflow_call:
     inputs:
       app-path:

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -61,21 +61,17 @@ jobs:
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use
-        id: package-manager
+        id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
-        run: ${{ steps.package-manager.outputs.install-command }}
-
+        run: ${{ env.PKG_CMD_INSTALL }}
       - name: Build packages
-        run: yarn ${{ inputs.build-command }}
-
+        run: ${{ env.PKG_CMD_RUN }} ${{ inputs.build-command }}
       - name: Change version for snapshot
-        run: yarn changeset version --snapshot ${{ inputs.snapshot-tag }}
+        run: ${{ env.PKG_CMD_EXEC }} changeset version --snapshot ${{ inputs.snapshot-tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish Snapshot
-        run: yarn changeset publish --tag ${{ inputs.snapshot-tag }} --snapshot --no-git-tag
-
+        run: ${{ env.PKG_CMD_EXEC }} changeset publish --tag ${{ inputs.snapshot-tag }} --snapshot --no-git-tag

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -34,24 +34,9 @@ env:
   CI: true
 
 jobs:
-  check-comment:
-    runs-on: [self-hosted, Linux, X64, cache]
-    if: github.event.action != 'closed'
-    outputs:
-      triggered: ${{ steps.check.outputs.triggered }}
-      extra_args: ${{ steps.check.outputs.extra_args }}
-    steps:
-      - uses: bucketplace/comment-trigger@v1.0
-        id: check
-        with:
-          trigger: '/snapshot'
-          reaction: rocket
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish:
     name: Run Changesets prerelease
     runs-on: [self-hosted, Linux, X64, cache, node-16]
-    needs: check-comment
     defaults:
       run:
         working-directory: ${{ inputs.app-path }}

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   check-comment:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, cache]
     if: github.event.action != 'closed'
     outputs:
       triggered: ${{ steps.check.outputs.triggered }}

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -41,6 +41,8 @@ jobs:
       run:
         working-directory: ${{ inputs.app-path }}
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -45,6 +45,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Use Node.js ${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+      - name: Configure registry
+        run: |
+          cat <<EOF > "$HOME/.npmrc"
+            //nexus.co-workerhou.se/repository/npm-private/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
       - name: Determine which package manager to use
         id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@feature/SC-59

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -28,6 +28,13 @@ on:
         required: false
         default: 'snap'
         type: string
+    secrets:
+      GITHUB_TOKEN:
+        description: "GitHub's default token for the current repository"
+        required: true
+      NEXUS_NPM_TOKEN:
+        description: "A Nexus NPM token for publishing packages"
+        required: true
 
 env:
   NODE_ENV: production

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -6,7 +6,7 @@ on:
       app-path:
         description: "Specifies a base directory to run the task from"
         required: false
-        default: './'
+        default: '.'
         type: string
       nodejs-version:
         description: "Specifies which Node.js version to use"

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -58,7 +58,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
       - name: Determine which package manager to use
         id: pkg-manager
-        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@feature/SC-59
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -29,9 +29,6 @@ on:
         default: 'snap'
         type: string
     secrets:
-      GITHUB_TOKEN:
-        description: "GitHub's default token for the current repository"
-        required: true
       NEXUS_NPM_TOKEN:
         description: "A Nexus NPM token for publishing packages"
         required: true

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   publish:
-    name: Run Changesets prerelease
+    name: Run Changesets snapshot
     runs-on: [self-hosted, Linux, X64, cache, node-16]
     defaults:
       run:

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -34,7 +34,7 @@ env:
   CI: true
 
 jobs:
-  publish:
+  snapshot:
     name: Run Changesets snapshot
     runs-on: [self-hosted, Linux, X64, cache, node-16]
     defaults:

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -62,12 +62,12 @@ jobs:
         with:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
-        run: ${{ env.PKG_CMD_INSTALL }}
+        run: ${{ steps.pkg-manager.outputs.install-cmd }}
       - name: Build packages
-        run: ${{ env.PKG_CMD_RUN }} ${{ inputs.build-command }}
+        run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.build-command }}
       - name: Change version for snapshot
-        run: ${{ env.PKG_CMD_EXEC }} changeset version --snapshot ${{ inputs.snapshot-tag }}
+        run: ${{ steps.pkg-manager.outputs.exec-cmd }} changeset version --snapshot ${{ inputs.snapshot-tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish snapshot
-        run: ${{ env.PKG_CMD_EXEC }} changeset publish --tag ${{ inputs.snapshot-tag }} --snapshot --no-git-tag
+        run: ${{ steps.pkg-manager.outputs.exec-cmd }} changeset publish --tag ${{ inputs.snapshot-tag }} --snapshot --no-git-tag


### PR DESCRIPTION
## Proposed Changes
- [FE Release Workflow Design Doc](https://docs.google.com/document/u/1/d/1crj7Q2QNJ6Wt5Aq-eTWjz9xt9OWxZDMI0cUdQJBgGOg/edit)에서 정의한 릴리즈 워크플로우를 각 서비스에서 손쉽게 구현할 수 있도록 패키징된 GitHub Workflows/Actions를 제공합니다.
- `select-nodejs-pkg-manager` action을 추가합니다: 자동으로 프로젝트의 package manager를 선택하고, install을 실행합니다.

## Test Status
(테스트를 어떻게 진행했는지 설명합니다.)
