### PR TITLE
chore: replace deprecated `set-output` command with environment file

### DIFF
--- a/.github/actions/release-tag-finder/action.yml
+++ b/.github/actions/release-tag-finder/action.yml
@@ -40,8 +40,8 @@ runs:
       run: |
         LATEST_TAG="${{ steps.find-latest-tag.outputs.tag }}"
         LATEST_VERSION="${LATEST_TAG#${{ inputs.app-name }}-v}"
-        echo "::set-output name=tag::${LATEST_TAG}"
-        echo "::set-output name=version::${LATEST_VERSION}"
+        echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+        echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Get Next SemVer
       id: next-semver
@@ -59,6 +59,6 @@ runs:
           GEN_VERSION="${{ steps.next-semver.outputs.major }}"
         fi
         GEN_TAG="${{ inputs.app-name }}-v${GEN_VERSION}"
-        echo "::set-output name=tag::${GEN_TAG}"
-        echo "::set-output name=version::${GEN_VERSION}"
+        echo "tag=${GEN_TAG}" >> $GITHUB_OUTPUT
+        echo "version=${GEN_VERSION}" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
## Proposed Changes

deprecated된 `set-output` 을 `$GITHUB_OUTPUT` 파일로 대체합니다.
자세한 내용은 [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)를 참고해주세요.

아래의 명령을 통해 `set-output`을 찾았습니다:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=tag::${LATEST_TAG}"
echo "::set-output name=version::${LATEST_VERSION}"
```

```yml
echo "::set-output name=tag::${GEN_TAG}"
echo "::set-output name=version::${GEN_VERSION}"
```

**TO-BE**

```yml
echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
```

```yml
echo "tag=${GEN_TAG}" >> $GITHUB_OUTPUT
echo "version=${GEN_VERSION}" >> $GITHUB_OUTPUT
```

## Test Status
N/A
