### PR TITLE
SC-97: CI 저장소 `main` 브랜치에 피쳐가 병합되면 자동으로 배포하는 스크립트 추가

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,21 @@
+name: "Tag Release Candidate"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag-release-candidate:
+    name: Tag release candidate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Update Git tag 'rc' to HEAD
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "rc"
+          force_push_tag: true
+          tag_exists_error: false
+          message: "Release Candidate"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,22 @@
 name: "Release CI Workflows and Actions"
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      increment:
+        type: choice
+        description: 'Increment version of release (major, minor, patch)'
+        required: true
+        default: 'patch'
+        choices:
+          - 'major'
+          - 'minor'
+          - 'patch'
 
 jobs:
   release-self:
     name: Run release on self
-    runs-on: [self-hosted, Linux, X64, no-cache]
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -17,20 +25,26 @@ jobs:
         id: version
         with:
           scheme: semver
-          increment: major
+          increment: ${{ github.event.inputs.increment }}
       - name: Create release
         uses: ncipollo/release-action@v1.12.0
         with:
           allowUpdates: true
           makeLatest: true
           generateReleaseNotes: true
-          name: ${{ steps.version.outputs.major-v-version }}
-          tag: ${{ steps.version.outputs.major-v-version }}
-          token: ${{ github.token }}
+          name: ${{ steps.version.outputs.v-version }}
+          tag: ${{ steps.version.outputs.v-version }}
+      - name: Update major git tag to HEAD
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "${{ steps.version.outputs.major-v-version }}"
+          force_push_tag: true
+          tag_exists_error: false
+          message: "${{ steps.version.outputs.major-v-version }} release: ${{ steps.version.outputs.v-version }}"
       - name: Update Git tag 'latest' to HEAD
         uses: rickstaa/action-create-tag@v1
         with:
           tag: "latest"
           force_push_tag: true
           tag_exists_error: false
-          message: "Latest release: ${{ steps.version.outputs.major-v-version }}"
+          message: "Latest release: ${{ steps.version.outputs.v-version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: "Release CI Workflows and Actions"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-self:
+    name: Run release on self
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Get next version
+        uses: reecetech/version-increment@2023.3.1
+        id: version
+        with:
+          scheme: semver
+          increment: major
+      - name: Create release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          allowUpdates: true
+          makeLatest: true
+          generateReleaseNotes: true
+          name: ${{ steps.version.outputs.major-v-version }}
+          tag: ${{ steps.version.outputs.major-v-version }}
+          token: ${{ github.token }}
+      - name: Update Git tag 'latest' to HEAD
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "latest"
+          force_push_tag: true
+          tag_exists_error: false
+          message: "Latest release: ${{ steps.version.outputs.major-v-version }}"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
 # Bucketplace CI Workflows
+
 Bucketplace의 Continuous Integration (CI)를 위한 공통 Workflows 를 제공하는 저장소입니다.
 
 각각의 Workflows의 설명은 아래 항목을 참조하세요.
 
-## 사용방법
-(TBD)
+## Usage
+
+변경사항이 `main` 브랜치에 병합되면 자동으로 `latest` 태그가 달려 모든 `bucketplace/*` 저장소에서 활용할 수 있게 배포됩니다.
+
+사용하는 단에선 다음 예시와 같이 지정하여 활용할 수 있습니다:
+
+```yml
+name: Run Node.js Test
+
+on:
+  - pull_request
+
+jobs:
+  run-test:
+    name: Run Node.js Test
+    uses: bucketplace/ci/.github/workflows/check-nodejs.yml@latest # << notice here
+```
 
 ## Workflows
-(TBD)
+
+전체 워크플로우 리스트는 [.github/workflows/*](https://github.com/bucketplace/ci/tree/main/.github/workflows) 폴더를 참조하세요.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
 ```
 
 필요에 따라 `latest`(사용 추천), `v1`(필요시), `rc`(야수의 심장 소유자) 등의 버전을 사용할 수 있습니다.
+
 ## Workflows & Actions
 
 재사용 가능한 워크플로우 리스트는 [.github/workflows/*](https://github.com/bucketplace/ci/tree/main/.github/workflows) 폴더를 참조하세요.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ jobs:
 
 재사용 가능한 액션 리스트는 [.github/actions/*](https://github.com/bucketplace/ci/tree/main/.github/actions) 폴더를 참조하세요
 
-
 ## How to Release new Version
 ```
  🚨 Github의 Release 기능을 이용하여 수동으로 release 하시면 안됩니다!

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bucketplace의 Continuous Integration (CI)를 위한 공통 Workflows 를 제공
 
 ## Usage
 
-변경사항이 `main` 브랜치에 병합되면 자동으로 `latest` 태그가 달려 모든 `bucketplace/*` 저장소에서 활용할 수 있게 배포됩니다.
+`bucketplace/*` 저장소에서 활용할 수 있는 action 및 reusable-workflow가 제공됩니다.
 
 사용하는 단에선 다음 예시와 같이 지정하여 활용할 수 있습니다:
 
@@ -22,6 +22,26 @@ jobs:
     uses: bucketplace/ci/.github/workflows/check-nodejs.yml@latest # << notice here
 ```
 
-## Workflows
+필요에 따라 `latest`(사용 추천), `v1`(필요시), `rc`(야수의 심장 소유자) 등의 버전을 사용할 수 있습니다.
+## Workflows & Actions
 
-전체 워크플로우 리스트는 [.github/workflows/*](https://github.com/bucketplace/ci/tree/main/.github/workflows) 폴더를 참조하세요.
+재사용 가능한 워크플로우 리스트는 [.github/workflows/*](https://github.com/bucketplace/ci/tree/main/.github/workflows) 폴더를 참조하세요.
+
+(이때 `release.yml`, `release-candidate.yml` 은 본 패키지를 위한 워크플로우이므로 재사용이 용이하지 않습니다.)
+
+재사용 가능한 액션 리스트는 [.github/actions/*](https://github.com/bucketplace/ci/tree/main/.github/actions) 폴더를 참조하세요
+
+
+## How to Release new Version
+```
+ 🚨 Github의 Release 기능을 이용하여 수동으로 release 하시면 안됩니다!
+```
+
+변경사항이 `main` 브랜치에 병합되면 자동으로 `rc` 태그가 달려 테스트가 가능해집니다.
+
+새로운 버전을 Release 할때는, 저장소 상단의 Actions 탭에서 `Release CI Workflows and Actions` Workflow를 선택합니다.
+
+그러면 우측 상단의 `Run workflow`라는 버튼이 있는데 이 버튼을 눌러 배포할 수 있습니다.
+
+이때, 어떤 버전을 올릴지 선택가능하며(major, minor, patch), 기본은 patch 버전이 올라갑니다.
+


### PR DESCRIPTION
## Proposed Changes
- 본 CI 저장소 `main` 브랜치에 피쳐가 병합되면 버전 범프 후 자동으로 배포하도록 워크플로우를 추가합니다.
  - `v*` 버전 태그 생성 후 `latest` 태그, GitHub Releases를 업데이트합니다.
- README 문서를 업데이트합니다.


## Test Status
- main에 병합되어야 테스트할 수 있습니다.
