### PR TITLE
[COREPL-599] Go & Ginkgo version auto detect

### DIFF
--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -121,8 +121,9 @@ jobs:
           cd ${{ inputs.app-path }} && \
           ginkgo -p --race --trace --cover --coverprofile=coverage.txt ./... && \
           gocov convert coverage.txt | gocov-xml > coverage.xml
+          ls -al
       - name: Create Coverage Information
-        if: always() && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: "${{ inputs.app-path }}/coverage.xml"
@@ -135,7 +136,6 @@ jobs:
           output: file
           thresholds: ${{ inputs.coverage-threshold }}
       - name: SonarQube Scanner Parameters Config
-        if: always()
         id: sonarqube-params
         uses: philips-software/sonar-scanner-action@v1.5.1
         with:

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -122,7 +122,7 @@ jobs:
           ginkgo -p --race --trace --cover --coverprofile=coverage.txt ./...
           gocov convert coverage.txt | gocov-xml > coverage.xml
       - name: Create Coverage Information
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: "${{ inputs.app-path }}/coverage.xml"
@@ -135,6 +135,7 @@ jobs:
           output: file
           thresholds: ${{ inputs.coverage-threshold }}
       - name: SonarQube Scanner Parameters Config
+        if: always()
         id: sonarqube-params
         uses: philips-software/sonar-scanner-action@v1.5.1
         with:

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -21,7 +21,6 @@ on:
         type: string
         description: go 버전
         required: false
-        default: "1.18"
       filter-mode:
         type: string
         description: reviewdog 결과 필터링 모드. [added, diff_context, file, nofilter] 중 하나
@@ -66,12 +65,13 @@ jobs:
           GONOSUMDB: "go.dailyhou.se"
         with:
           reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]
+          workdir: ${{ inputs.app-path }}
           go_version: ${{ inputs.go-version }}
+          go_version_file: ${{ inputs.app-path}}/go.mod
           reporter: ${{ inputs.reporter }}
           filter_mode: ${{ inputs.filter-mode }}
           fail_on_error: true
-          workdir: ${{ inputs.app-path }}
-          golangci_lint_version: v1.50.1
+          golangci_lint_version: v1.52.2 # last update: 2023.03.29
           golangci_lint_flags: |
             --config=${{ inputs.lint-config }} ./...
 
@@ -95,11 +95,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           cache: true
           cache-dependency-path: ${{ inputs.app-path }}/go.sum
-          go-version: ^${{ inputs.go-version }}
+          go-version-file: ${{ inputs.app-path }}/go.mod
+          go-version: ${{ inputs.go-version }}
       - name: Granting private modules access
         env:
           TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
@@ -112,7 +113,7 @@ jobs:
           go env -w GONOSUMDB=go.dailyhou.se && \
           go install github.com/axw/gocov/gocov@latest && \
           go install github.com/AlekSi/gocov-xml@latest && \
-          go install github.com/onsi/ginkgo/v2/ginkgo@v2.5.1
+          cd ${{ inputs.app-path }} && go install github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Test
         run: |

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -119,9 +119,8 @@ jobs:
         run: |
           export PATH=$(go env GOPATH)/bin:$PATH && \
           cd ${{ inputs.app-path }} && \
-          ginkgo -p --race --trace --cover --coverprofile=coverage.txt ./... && \
+          ginkgo -p --race --trace --cover --coverprofile=coverage.txt ./...
           gocov convert coverage.txt | gocov-xml > coverage.xml
-          ls -al
       - name: Create Coverage Information
         if: github.event_name == 'pull_request'
         uses: irongut/CodeCoverageSummary@v1.3.0


### PR DESCRIPTION
- golangci-lint 버전을 업데이트했습니다.
- Ginkgo 버전을 애플리케이션에서 사용 중인 버전으로 설치합니다.
- Go 버전을 go.mod에서 찾을 수 있게 합니다. `go-version`을 명시하면 해당 버전을 사용합니다.

## Test Status
- [테스트](https://github.com/bucketplace/watchcat/actions/runs/4559917209)