### PR TITLE
COREPL-950 fix: set-output in jacoco-report action

### DIFF
--- a/.github/workflows/check-kotlin-gradle.yml
+++ b/.github/workflows/check-kotlin-gradle.yml
@@ -125,7 +125,7 @@ jobs:
           path: ${{ inputs.app-path }}/build/reports/
       - if: ( success() || failure() ) && github.event_name != 'workflow_dispatch'
         name: Add coverage to PR
-        uses: madrapps/jacoco-report@v1.3
+        uses: madrapps/jacoco-report@v1.4
         with:
           paths: ${{ (inputs.jacoco-reports != '' && inputs.jacoco-reports) || format('{0}/build/reports/jacoco/test/jacocoTestReport.xml', inputs.app-path) }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Proposed Changes
- `madrapps/jacoco-report` 의 [set-output 대응 패치한 버전](https://github.com/Madrapps/jacoco-report/releases/tag/v1.4)으로 액션을 최신화합니다.


## Test Status
(테스트를 어떻게 진행했는지 설명합니다.)
