### PR TITLE
chore: make ginkgo and sonarqube optional

### DIFF
--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -151,8 +151,19 @@ jobs:
           indicators: true
           output: file
           thresholds: ${{ inputs.coverage-threshold }}
-      - name: SonarQube Scanner Parameters Config
+      - name: SonarQube Config Validation
         if: always() && inputs.use-sonar-report
+        id: sonarqube-validation
+        shell: bash
+        run: |
+          if [ ${{ secrets.SONAR_TOKEN == null }}
+          then
+            echo "SONAR_TOKEN secret is required. SonarQube steps will be skipped." 
+            echo "sonarqube-available=false" >> $GITHUB_OUTPUT
+          else
+            echo "sonarqube-available=true" >> $GITHUB_OUTPUT
+      - name: SonarQube Scanner Parameters Config
+        if: always() && steps.sonarqube-validation.outputs.sonarqube-available == "true"
         id: sonarqube-params
         uses: philips-software/sonar-scanner-action@v1.5.1
         with:
@@ -165,7 +176,7 @@ jobs:
           organization: bucketplace
           onlyConfig: true
       - name: SonarQube Scan
-        if: inputs.use-sonar-report
+        if: inputs.use-sonar-report && steps.sonarqube-validation.outputs.sonarqube-available == "true"
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -130,7 +130,7 @@ jobs:
           && go install github.com/onsi/ginkgo/v2/ginkgo && \
           ginkgo -p --race --trace --cover --coverprofile=coverage.txt ./...
       - name: Test with Go Test
-        if: !inputs.use-ginkgo
+        if: ${{ !inputs.use-ginkgo }}
         run: |
           export PATH=$(go env GOPATH)/bin:$PATH && cd ${{ inputs.app-path }} && \
           go test -v -cover -coverprofile=coverage.txt ./...

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -156,12 +156,13 @@ jobs:
         id: sonarqube-validation
         shell: bash
         run: |
-          if [ ${{ secrets.SONAR_TOKEN == null }}
+          if [ ${{ secrets.SONAR_TOKEN == null }} == "true" ]
           then
             echo "SONAR_TOKEN secret is required. SonarQube steps will be skipped." 
             echo "sonarqube-available=false" >> $GITHUB_OUTPUT
           else
             echo "sonarqube-available=true" >> $GITHUB_OUTPUT
+          fi
       - name: SonarQube Scanner Parameters Config
         if: always() && ${{ steps.sonarqube-validation.outputs.sonarqube-available == "true" }}
         id: sonarqube-params
@@ -176,7 +177,7 @@ jobs:
           organization: bucketplace
           onlyConfig: true
       - name: SonarQube Scan
-        if: inputs.use-sonar-report && ${{ steps.sonarqube-validation.outputs.sonarqube-available == "true" }}
+        if: ${{ steps.sonarqube-validation.outputs.sonarqube-available == "true" }}
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -40,9 +40,17 @@ on:
         description: "unit test coverage threshold"
         required: false
         default: "70 70"
+      use-ginkgo:
+        description: "테스트를 위해 Ginkgo CLI를 사용할 것인지 여부"
+        required: false
+        default: true
+      use-sonar-report:
+        description: "sonarqube 리포트를 사용할 것인지 여부"
+        required: false
+        default: true
     secrets:
       SONAR_TOKEN:
-        required: true
+        required: false
       BP_DEPLOYER_GITHUB_TOKEN: # if you need private github module access
         required: false
 jobs:
@@ -112,14 +120,21 @@ jobs:
           go env -w GOPROXY=https://go.co-workerhou.se,https://proxy.golang.org,direct && \
           go env -w GONOSUMDB=go.dailyhou.se && \
           go install github.com/axw/gocov/gocov@latest && \
-          go install github.com/AlekSi/gocov-xml@latest && \
-          cd ${{ inputs.app-path }} && go install github.com/onsi/ginkgo/v2/ginkgo
-
-      - name: Test
+          go install github.com/AlekSi/gocov-xml@latest
+      - name: Test with Ginkgo
+        if: inputs.use-ginkgo
         run: |
-          export PATH=$(go env GOPATH)/bin:$PATH && \
-          cd ${{ inputs.app-path }} && \
+          export PATH=$(go env GOPATH)/bin:$PATH && cd ${{ inputs.app-path }} && \
+          && go install github.com/onsi/ginkgo/v2/ginkgo && \
           ginkgo -p --race --trace --cover --coverprofile=coverage.txt ./...
+      - name: Test with Go Test
+        if: !inputs.use-ginkgo
+        run: |
+          export PATH=$(go env GOPATH)/bin:$PATH && cd ${{ inputs.app-path }} && \
+          go test -v -cover -coverprofile=coverage.txt ./...
+      - name: Convert Coverage Format
+        run: |
+          export PATH=$(go env GOPATH)/bin:$PATH && cd ${{ inputs.app-path }} && \
           gocov convert coverage.txt | gocov-xml > coverage.xml
       - name: Create Coverage Information
         if: always() && github.event_name == 'pull_request'
@@ -135,7 +150,7 @@ jobs:
           output: file
           thresholds: ${{ inputs.coverage-threshold }}
       - name: SonarQube Scanner Parameters Config
-        if: always()
+        if: always() && inputs.use-sonar-report
         id: sonarqube-params
         uses: philips-software/sonar-scanner-action@v1.5.1
         with:
@@ -148,6 +163,7 @@ jobs:
           organization: bucketplace
           onlyConfig: true
       - name: SonarQube Scan
+        if: inputs.use-sonar-report
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -41,10 +41,12 @@ on:
         required: false
         default: "70 70"
       use-ginkgo:
+        type: boolean
         description: "테스트를 위해 Ginkgo CLI를 사용할 것인지 여부"
         required: false
         default: true
       use-sonar-report:
+        type: boolean
         description: "sonarqube 리포트를 사용할 것인지 여부"
         required: false
         default: true

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -163,7 +163,7 @@ jobs:
           else
             echo "sonarqube-available=true" >> $GITHUB_OUTPUT
       - name: SonarQube Scanner Parameters Config
-        if: always() && steps.sonarqube-validation.outputs.sonarqube-available == "true"
+        if: always() && ${{ steps.sonarqube-validation.outputs.sonarqube-available == "true" }}
         id: sonarqube-params
         uses: philips-software/sonar-scanner-action@v1.5.1
         with:
@@ -176,7 +176,7 @@ jobs:
           organization: bucketplace
           onlyConfig: true
       - name: SonarQube Scan
-        if: inputs.use-sonar-report && steps.sonarqube-validation.outputs.sonarqube-available == "true"
+        if: inputs.use-sonar-report && ${{ steps.sonarqube-validation.outputs.sonarqube-available == "true" }}
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -78,7 +78,7 @@ jobs:
           workdir: ${{ inputs.app-path }}
           go_version: ${{ inputs.go-version }}
           go_version_file: ${{ inputs.app-path}}/go.mod
-          reporter: ${{ inputs.reporter }}
+          reporter: github-pr-check
           filter_mode: ${{ inputs.filter-mode }}
           fail_on_error: true
           golangci_lint_version: v1.52.2 # last update: 2023.03.29
@@ -156,7 +156,7 @@ jobs:
         id: sonarqube-validation
         shell: bash
         run: |
-          if [ ${{ secrets.SONAR_TOKEN == null }} == "true" ]
+          if [ ${{ secrets.SONAR_TOKEN == null }} ]
           then
             echo "SONAR_TOKEN secret is required. SonarQube steps will be skipped." 
             echo "sonarqube-available=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-golang.yml
+++ b/.github/workflows/check-golang.yml
@@ -70,7 +70,7 @@ jobs:
           git config --global url."https://bp-deployer:${TOKEN}@github.com/bucketplace/".insteadOf "https://github.com/bucketplace/"
       - name: Lint
         uses: reviewdog/action-golangci-lint@v2
-        env:                                                                    
+        env:
           GOPROXY: "https://go.co-workerhou.se,https://proxy.golang.org,direct"
           GONOSUMDB: "go.dailyhou.se"
         with:
@@ -164,7 +164,7 @@ jobs:
             echo "sonarqube-available=true" >> $GITHUB_OUTPUT
           fi
       - name: SonarQube Scanner Parameters Config
-        if: always() && ${{ steps.sonarqube-validation.outputs.sonarqube-available == "true" }}
+        if: ${{ always() && steps.sonarqube-validation.outputs.sonarqube-available == true }}
         id: sonarqube-params
         uses: philips-software/sonar-scanner-action@v1.5.1
         with:
@@ -177,7 +177,7 @@ jobs:
           organization: bucketplace
           onlyConfig: true
       - name: SonarQube Scan
-        if: ${{ steps.sonarqube-validation.outputs.sonarqube-available == "true" }}
+        if: steps.sonarqube-validation.outputs.sonarqube-available == true
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Proposed Changes
- SonarQube가 Deprecated 되어 Optional하게 사용할 수 있도록 플래그를 붙였습니다.
- Ginkgo를 아예 사용하고 있지 않은 경우 CLI 설치에 에러가 나는데, 기본 테스트 툴로 테스트를 할 수 있도록 플래그를 붙였습니다.


## Test Status
- [Test Action](https://github.com/bucketplace/feature-flag/actions/runs/5219417018/jobs/9422360495)
