### PR TITLE
Feat: latest-tag-finder action 추가

### DIFF
--- a/.github/actions/latest-tag-finder/README.md
+++ b/.github/actions/latest-tag-finder/README.md
@@ -1,0 +1,23 @@
+## Latest Tag Finder
+
+현재 브랜치에서 가장 높은 버전의 Tag를 찾고, 필요시 다음 태그를 생성해준다.
+
+release-tag-finder와 가장 큰 차이는 현재 Branch 를 기준으로 히스토리를 따라가면 찾아 주기 때문에 여러 브랜치에서 서로다른 버전이 배포될 때 유용합니다.
+
+# Inputs
+| **Input** | **Description**                                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------------------------------- |
+| `prefix`  | 찾고자 하는 버전의 Prefix (eg. sample-service-v)                                                                    |
+| `bump`    | SemVer 버전의 어떤 파트를 올릴지 선택하는 옵션. 필수이며 기본값은 `patch` 이다. (`major`, `minor`, `patch` 중 택 1) |
+| `ref`     | 어디서부터 Tag를 찾을지 결정 기본값은 action이 실행된 ref                                                           |
+
+# Outputs
+| **Output**        | **Description**                                               |
+| ----------------- | ------------------------------------------------------------- |
+| `next-tag`        | 다음 Tag, prefix가 포함되어 있습니다. (sample-service-v1.0.2) |
+| `current-tag`     | 현재 Tag, prefix가 포함되어 있습니다. (sample-service-v1.0.1) |
+| `next-version`    | 다음 Version, prefix가 없이 버전만 표시됩니다. (1.0.2)        |
+| `current-version` | 현재 Version, prefix가 없이 버전만 표시됩니다. (1.0.1)        |
+| `major`           | 다음 버전의 major 버전 (1)                                    |
+| `minor`           | 다음 버전의 minor 버전 (0)                                    |
+| `patch`           | 다음 버전의 patch 버전 (2)                                    |

--- a/.github/actions/latest-tag-finder/action.yml
+++ b/.github/actions/latest-tag-finder/action.yml
@@ -1,4 +1,4 @@
-name: "Release Tag Finder"
+name: "Latest Tag Finder"
 description: "finds release tags and generate next tag with app name"
 inputs:
   prefix:
@@ -8,6 +8,10 @@ inputs:
   bump:
     description: "next tag에서 SemVer 어떤 부분(major, minor, patch)를 올릴지 결정"
     default: "patch"
+    required: false
+  ref:
+    description: "어디서부터 Tag를 찾을지 결정 기본값은 action이 실행된 ref"
+    default: ''
     required: false
 outputs:
   next-tag:
@@ -34,21 +38,23 @@ outputs:
   
 runs:
   using: composite
+  env: 
+    TEMP_DIR: ${{ github.workspace }}/__temp__99
   steps:
-    - name: "Find Latest Tags for new Version"
-      id: find-latest-tag  # The step ID to refer to later.
-      uses: oprypin/find-latest-tag@v1
+    - name: "Checkout all Tags"
+      id: checkout-tags
+      uses: actions/checkout@v3
       with:
-        repository: ${{ github.repository }}
-        releases-only: true
-        prefix: ${{ inputs.prefix }}
-    - name: Get Current Tag and Version
-      id: current-tag
+        fetch-depth: 0
+        ref: ${{ inputs.ref }}
+        path: ${TEMP_DIR}
+    - name: "Find Current Tag"
+      id: current-tag  # The step ID to refer to later.
       run: |
-        LATEST_TAG="${{ steps.find-latest-tag.outputs.tag }}"
-        LATEST_VERSION="${LATEST_TAG#${{ inputs.prefix }}}"
-        echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
-        echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+        cd ${TEMP_DIR}
+        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | sort --version-sort -r | head -n 1 | tr -d '[:space:]')
+        echo "version=${LATEST_TAG#${{ inputs.prefix }}}" >> $GITHUB_OUTPUT
+        rm -rf ${TEMP_DIR}
       shell: bash
     - name: Parsing SemVer
       uses: madhead/semver-utils@latest

--- a/.github/actions/latest-tag-finder/action.yml
+++ b/.github/actions/latest-tag-finder/action.yml
@@ -80,4 +80,3 @@ runs:
       id: next-version
       with:
         version: ${{ steps.generate-next-tag.outputs.version }}
-      

--- a/.github/actions/multimodule-changelog/action.yml
+++ b/.github/actions/multimodule-changelog/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Get Tags
       id: get-tag
-      uses: bucketplace/ci/.github/actions/release-tag-finder@latest
+      uses: bucketplace/ci/.github/actions/latest-tag-finder@latest
       with:
         prefix: '${{ inputs.module }}${{ inputs.divider }}'
         bump: '${{ github.event.inputs.bump }}'

--- a/.github/actions/release-tag-finder/README.md
+++ b/.github/actions/release-tag-finder/README.md
@@ -1,0 +1,23 @@
+## Release Tag Finder
+
+현재 릴리즈된 가장 높은 버전의 태그를 찾고, 필요시 다음 태그를 생성해준다.
+
+latest-tag-finder와 가장 큰 차이는 실행 브랜치와 상관없이 전체 repository에서 가장 높은 버전의 태그를 찾기 때문에, 하나 이상의 버전을 유지할 때는 유용하지 않습니다.
+
+# Inputs
+| **Input** | **Description**                                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------------------------------- |
+| `prefix`  | 찾고자 하는 버전의 Prefix (eg. sample-service-v)                                                                    |
+| `bump`    | SemVer 버전의 어떤 파트를 올릴지 선택하는 옵션. 필수이며 기본값은 `patch` 이다. (`major`, `minor`, `patch` 중 택 1) |
+| `ref`     | 어디서부터 Tag를 찾을지 결정 기본값은 action이 실행된 ref                                                           |
+
+# Outputs
+| **Output**        | **Description**                                               |
+| ----------------- | ------------------------------------------------------------- |
+| `next-tag`        | 다음 Tag, prefix가 포함되어 있습니다. (sample-service-v1.0.2) |
+| `current-tag`     | 현재 Tag, prefix가 포함되어 있습니다. (sample-service-v1.0.1) |
+| `next-version`    | 다음 Version, prefix가 없이 버전만 표시됩니다. (1.0.2)        |
+| `current-version` | 현재 Version, prefix가 없이 버전만 표시됩니다. (1.0.1)        |
+| `major`           | 다음 버전의 major 버전 (1)                                    |
+| `minor`           | 다음 버전의 minor 버전 (0)                                    |
+| `patch`           | 다음 버전의 patch 버전 (2)                                    |

--- a/.github/actions/release-tag-finder/action.yml
+++ b/.github/actions/release-tag-finder/action.yml
@@ -74,4 +74,3 @@ runs:
       id: next-version
       with:
         version: ${{ steps.generate-next-tag.outputs.version }}
-      


### PR DESCRIPTION
## Proposed Changes
기존에 release-tag-finder 라는 Action이 있었습니다만, 해당 액션은 repository 전체의 tag를 가져오도록 구성이 되어 있어, 특정 브랜치의 Tag만 가져오는 것이 불가능함.

최근에 mortar v2가 배포되면서 main(v2), main-v1(v1)으로 두개의 브랜치에서 배포할 필요성이 생겼으나, v1에서 해도 항상 v2의 버전이 최 상위에 올라올 수 밖에 없도록 구성됨.

따라서 v1 배포에 문제가 발생. 또 v2 배포시점에도 최신 (날짜기준) 버전 v1이 되는 경우가 있어 두 브랜치 다에서 문제가 발생함.

이에 latest-tag-finder를 만들었음. 이 finder는 현재 ref 기준으로 브랜치 내의 모든 tag만 가져오도록 되어 있어, 다른 브랜치의 tag와 상관없이 하나의 브랜치 내에서 tag history를 유지할 수 있음.
