### PR TITLE
fix: Update runner node version to 18

### DIFF
--- a/.github/workflows/check-nodejs.yml
+++ b/.github/workflows/check-nodejs.yml
@@ -6,27 +6,27 @@ on:
       app-path:
         description: "Specifies a base directory to run the task from"
         required: false
-        default: '.'
+        default: "."
         type: string
       nodejs-version:
         description: "Specifies which Node.js version to use"
         required: false
-        default: '18'
+        default: "18"
         type: string
       package-manager:
         description: "Specifies which package manager to use"
         required: false
-        default: ''
+        default: ""
         type: string
       test-command:
         description: "Specifies a test command that will be passed to the package manager"
         required: false
-        default: 'test'
+        default: "test"
         type: string
       test-command-args:
         description: "Specifies an optional arguments to the test command"
         required: false
-        default: ''
+        default: ""
         type: string
 
 env:
@@ -36,7 +36,7 @@ env:
 jobs:
   run-test:
     name: Run Node.js test
-    runs-on: [self-hosted, Linux, X64, cache, node-16]
+    runs-on: [self-hosted, Linux, X64, cache, node-18]
     defaults:
       run:
         working-directory: ${{ inputs.app-path }}

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -6,27 +6,27 @@ on:
       app-path:
         description: "Specifies a base directory to run the task from"
         required: false
-        default: '.'
+        default: "."
         type: string
       nodejs-version:
         description: "Specifies which Node.js version to use"
         required: false
-        default: '18'
+        default: "18"
         type: string
       package-manager:
         description: "Specifies which package manager to use"
         required: false
-        default: ''
+        default: ""
         type: string
       build-command:
         description: "Specifies a build command used on package finalizing before publish"
         required: false
-        default: 'build'
+        default: "build"
         type: string
       prerelease-tag:
         description: "Specifies a tag name that is used for prerelease mode"
         required: false
-        default: 'pre'
+        default: "pre"
         type: string
     secrets:
       NEXUS_NPM_TOKEN:
@@ -40,7 +40,7 @@ env:
 jobs:
   prerelease:
     name: Run Changesets prerelease
-    runs-on: [self-hosted, Linux, X64, cache, node-16]
+    runs-on: [self-hosted, Linux, X64, cache, node-18]
     defaults:
       run:
         working-directory: ${{ inputs.app-path }}
@@ -76,7 +76,7 @@ jobs:
       - name: Commit
         uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
         with:
-          add: '.'
+          add: "."
           committer_name: bp-deployer
           committer_email: bp-deployer@users.noreply.github.com
-          message: '[skip actions] Prerelease ${{inputs.prerelease-tag}}'
+          message: "[skip actions] Prerelease ${{inputs.prerelease-tag}}"

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -6,22 +6,22 @@ on:
       app-path:
         description: "Specifies a base directory to run the task from"
         required: false
-        default: '.'
+        default: "."
         type: string
       nodejs-version:
         description: "Specifies which Node.js version to use"
         required: false
-        default: '18'
+        default: "18"
         type: string
       package-manager:
         description: "Specifies which package manager to use"
         required: false
-        default: ''
+        default: ""
         type: string
       build-command:
         description: "Specifies a build command used on package finalizing before publish"
         required: false
-        default: 'build'
+        default: "build"
         type: string
     secrets:
       NEXUS_NPM_TOKEN:
@@ -35,7 +35,7 @@ env:
 jobs:
   publish:
     name: Run Changesets publish
-    runs-on: [self-hosted, Linux, X64, cache, node-16]
+    runs-on: [self-hosted, Linux, X64, cache, node-18]
     defaults:
       run:
         working-directory: ${{ inputs.app-path }}

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -6,22 +6,22 @@ on:
       app-path:
         description: "Specifies a base directory to run the task from"
         required: false
-        default: '.'
+        default: "."
         type: string
       nodejs-version:
         description: "Specifies which Node.js version to use"
         required: false
-        default: '18'
+        default: "18"
         type: string
       package-manager:
         description: "Specifies which package manager to use"
         required: false
-        default: ''
+        default: ""
         type: string
       build-command:
         description: "Specifies a build command used on package finalizing before publish"
         required: false
-        default: 'build'
+        default: "build"
         type: string
       branch:
         description: "Specifies which branch ref to use on checkout"
@@ -31,7 +31,7 @@ on:
       snapshot-tag:
         description: "Specifies a tag name that is used for snapshot release"
         required: false
-        default: 'snap'
+        default: "snap"
         type: string
     outputs:
       pkg-version-name-pairs:
@@ -49,7 +49,7 @@ env:
 jobs:
   snapshot:
     name: Run Changesets snapshot
-    runs-on: [self-hosted, Linux, X64, cache, node-16]
+    runs-on: [self-hosted, Linux, X64, cache, node-18]
     defaults:
       run:
         working-directory: ${{ inputs.app-path }}


### PR DESCRIPTION
## Proposed Changes
- Node.js 워크플로우의 runner 버전이 워크플로우 설정 값과 다르던 부분을 수정합니다.
- NVM을 사용하므로 실질적인 차이는 없을 것으로 보입니다.

## Test Status
워크플로우 배포 후 테스트가 필요합니다.
