### PR TITLE
COREPL-1211 feat: support mortar multi-version

### DIFF
--- a/.github/workflows/check-kotlin-gradle.yml
+++ b/.github/workflows/check-kotlin-gradle.yml
@@ -16,6 +16,11 @@ on:
         description: "앱 기준 디렉토리"
         required: false
         default: "."
+      mortar-version:
+        type: string
+        description: "mortar 버전 (JVM 17이상시 v2, 이하시 v1)"
+        required: false
+        default: "v1"
       gradlew-path:
         type: string
         description: "gradlew가 있는 path"
@@ -47,7 +52,7 @@ on:
 jobs:
   check-and-report:
     name: Lint, Test And Reports
-    runs-on: [self-hosted, Linux, X64, mortar-runner]
+    runs-on: [ "self-hosted", "Linux", "X64", "mortar", ${{ inputs.mortar-version }} ]
     steps:
       - name: Load Build Cache
         id: load-build-cache

--- a/.github/workflows/check-kotlin-gradle.yml
+++ b/.github/workflows/check-kotlin-gradle.yml
@@ -52,7 +52,7 @@ on:
 jobs:
   check-and-report:
     name: Lint, Test And Reports
-    runs-on: [ "self-hosted", "Linux", "X64", "mortar", ${{ inputs.mortar-version }} ]
+    runs-on: [ "self-hosted", "Linux", "X64", "mortar", "${{ inputs.mortar-version }}" ]
     steps:
       - name: Load Build Cache
         id: load-build-cache


### PR DESCRIPTION
## Proposed Changes
- `check-kotlin-gradle` workflow 에서 mortar multi-version 지원을 위하여  mortar-version 에 따라 mortar-runner 할당을 위한 태그를 지정하여줍니다.

## Reference
- Dynamic Runs-On [Configurations](https://github.com/actions/runner/issues/409#issuecomment-1206725030)
- Mortar Multi-Version Github Action Runner [Configurations](https://www.notion.so/ohouse/Mortar-v2-f0aabff5bae249568c8cbba3faa9fd28?pvs=4#dabf4ded7e4041b58553ed460e49e760)

## Comment
- 이 방법보다는, 사용하는 측에서 runs-on을 오버라이드 하는게 맞을까요? PR을 작성하고 알았는데, runs-on을 오버라이드도 되는 것 같은 느낌입니다. 맞을까요? @edwarddoh 

## Test Status
- `platform-service` [테스트](https://github.com/bucketplace/platform-service/pull/3) 완료
