### PR TITLE
SC-350: SonarCloud: FE 워크플로우에서 lint/lcov 명령이 non-zero exit 인 경우에도 재개 허용

### DIFF
--- a/.github/workflows/reusable-sonarcloud-analysis-nodejs.yml
+++ b/.github/workflows/reusable-sonarcloud-analysis-nodejs.yml
@@ -67,8 +67,10 @@ jobs:
         run: ${{ steps.pkg-manager.outputs.install-cmd }}
       - name: Run lint and report
         run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.lint-command }} ${{ inputs.lint-command-args }}
+        continue-on-error: true
       - name: Collect test coverage report
         run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.lcov-command }} ${{ inputs.lcov-command-args }}
+        continue-on-error: true
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:


### PR DESCRIPTION
## Proposed Changes
- ESLint의 경우 린트에 실패할 경우 non-zero exit(1)을 합니다. 하지만 이런 경우에도 리포트는 정상적으로 생성되며 SonarCloud에 이 리포트를 업로드해야 하므로 lint/lcov 명령이 실패하더라도 워크플로우 진행은 계속되어야 합니다.
- 따라서, 각 run 명령에 `continue-on-error: true` 를 추가합니다.


## Test Status
RC 배포 후 테스트합니다.
