### PR TITLE
[SC-389] Web FE 하이브리드 Test/SonarCloud 워크플로우 추가

### DIFF
--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -84,7 +84,7 @@ jobs:
           fi
       - name: Run SonarCloud prepare
         if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true'
-        run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.sonarcloud }} ${{ inputs.sonarcloud-command-args }}
+        run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.sonarcloud-command }} ${{ inputs.sonarcloud-command-args }}
         continue-on-error: true
       - name: SonarCloud scan
         if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true'

--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -1,0 +1,94 @@
+name: "Check Web"
+
+on:
+  workflow_call:
+    inputs:
+      app-path:
+        description: "Specifies a base directory to run the task from"
+        required: false
+        default: "."
+        type: string
+      nodejs-version:
+        description: "Specifies which Node.js version to use"
+        required: false
+        default: "18"
+        type: string
+      package-manager:
+        description: "Specifies which package manager to use (leave empty to auto-detect)"
+        required: false
+        default: ""
+        type: string
+      test-command:
+        description: "Specifies a script name that runs tests"
+        required: false
+        default: "test"
+        type: string
+      test-command-args:
+        description: "Specifies optional arguments to the test command"
+        required: false
+        default: ""
+        type: string
+      sonarcloud-command:
+        description: "Specifies a script name that will prepare materials for uploading to SonarCloud (executed only when there's SonarCloud config exists)"
+        required: false
+        default: "sonarcloud"
+        type: string
+      sonarcloud-command-args:
+        description: "Specifies optional arguments to the sonarcloud command"
+        required: false
+        default: ""
+        type: string
+    secrets:
+      SONAR_TOKEN:
+        description: "A SonarCloud token for uploading reports"
+        required: false
+
+env:
+  NODE_ENV: development # This must always be set. Otherwise, required dependencies to run test will not be installed or inconsistency happens.
+  CI: true
+
+jobs:
+  run-checks:
+    name: Run checks and report
+    runs-on: [self-hosted, Linux, X64, cache, node-18]
+    defaults:
+      run:
+        working-directory: ${{ inputs.app-path }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Use Node.js ${{ inputs.nodejs-version }}
+        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+      - name: Determine which package manager to use
+        id: pkg-manager
+        uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
+        with:
+          app-path: ${{ inputs.app-path }}
+          package-manager: ${{ inputs.package-manager }}
+      - name: Install dependencies
+        run: ${{ steps.pkg-manager.outputs.install-cmd }}
+      - name: Run test
+        run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.test-command }} ${{ inputs.test-command-args }}
+      - name: Check if SonarCloud is configured
+        id: check-sonarcloud-configured
+        shell: bash
+        run: |
+          if [[ -f "${{ inputs.app-path }}/sonar-project.properties" ]]; then
+            echo "SonarCloud is configured."
+            echo "sonar-ready=true" >> $GITHUB_OUTPUT
+          else
+            echo "SonarCloud is not configured."
+            echo "sonar-ready=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Run SonarCloud prepare
+        if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true'
+        run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.sonarcloud }} ${{ inputs.sonarcloud-command-args }}
+        continue-on-error: true
+      - name: SonarCloud scan
+        if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true'
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Use Node.js ${{ inputs.nodejs-version }}
+      - name: Use Node.js v${{ inputs.nodejs-version }}
         run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
       - name: Determine which package manager to use
         id: pkg-manager
@@ -71,15 +71,15 @@ jobs:
         run: ${{ steps.pkg-manager.outputs.install-cmd }}
       - name: Run test
         run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.test-command }} ${{ inputs.test-command-args }}
-      - name: Check if SonarCloud is configured
+      - name: Check whether SonarCloud is configured
         id: check-sonarcloud-configured
         shell: bash
         run: |
           if [[ -f "${{ inputs.app-path }}/sonar-project.properties" ]]; then
-            echo "SonarCloud is configured."
+            echo "SonarCloud configuration detected, will run analysis."
             echo "sonar-ready=true" >> $GITHUB_OUTPUT
           else
-            echo "SonarCloud is not configured."
+            echo "SonarCloud configuration not detected, will skip analysis."
             echo "sonar-ready=false" >> $GITHUB_OUTPUT
           fi
       - name: Run SonarCloud prepare


### PR DESCRIPTION
## Proposed Changes
- [SonarCloud onboarding 중 논의](https://ohou-se.slack.com/archives/C05M5U8MKHQ/p1693992165675859?thread_ts=1693969722.905769&cid=C05M5U8MKHQ)된 FE 프로젝트 린팅 및 타입체크에 대한 대응 결론에 따라 web fe 프로젝트 전반에 사용할 수 있는 "Check Web" 하이브리드 워크플로우를 작성합니다.
- "Check Web" 하이브리드 워크플로우는 SonarCloud 프로젝트 설정이 없으면 [순수 Node.js 테스트 워크플로우](https://www.notion.so/CI-Node-js-Test-bfba167b7f9047f8a7df458b50d7e4d6)로 작동합니다.
- 만약 [SonarCloud: FE](https://www.notion.so/ohouse/SonarCloud-FE-a5c83f4034fb40c8be7d4ab5cf866164#41759839b18d4727b49a6fcc2c4b0392) 가이드에 따라 적용된 설정이 있는 경우, 리포트 업로드도 함께 진행하도록 기전이 변경됩니다.

## Test Status
[ohouse-divops](https://github.com/bucketplace/ohouse-divops) 프로젝트에 시범 적용함으로써 테스트합니다.
