### PR TITLE
[SC-399] Web Checks 워크플로우의 sonarcloud prepare 스크립트 분기 추가

### DIFF
--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -82,10 +82,10 @@ jobs:
             echo "SonarCloud configuration not detected, will skip analysis."
             echo "sonar-ready=false" >> $GITHUB_OUTPUT
           fi
+          node -e "process.stdout.write(`prepare-script=${String(require('./package.json')?.scripts?.sonarcloud != null)}`)" 2>&1 >> $GITHUB_OUTPUT
       - name: Run SonarCloud prepare
-        if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true'
+        if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true' && steps.check-sonarcloud-configured.outputs.prepare-script == 'true'
         run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.sonarcloud-command }} ${{ inputs.sonarcloud-command-args }}
-        continue-on-error: true
       - name: SonarCloud scan
         if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true'
         uses: SonarSource/sonarcloud-github-action@master


### PR DESCRIPTION
## Proposed Changes
- Web Checks 워크플로우 내의 SonarCloud prepare 스크립트를 항상 실행하는 것이 아닌, `package.json`에 스크립트가 존재할 때만 실행합니다.
- 이 변경을 추가함으로써 GitHub Actions 실행시 `sonarcloud` 스크립트가 없어 경고가 나오는 현상(단, 실패하지는 않음)을 해소할 수 있습니다.

## Test Status
https://github.com/bucketplace/ohouse-divops 에 우선적으로 적용하여 테스트합니다.
