### PR TITLE
[SC-451] Web Checks 워크플로우에 자동으로 --max-old-space-size 설정하는 스탭 추가

### DIFF
--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -85,6 +85,10 @@ jobs:
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
         run: ${{ steps.pkg-manager.outputs.install-cmd }}
+      - name: Calculate available system memory for heap allocation
+        id: calc-system-memory
+        shell: bash
+        run: echo "available=$(expr $(echo "$(free -m)" | awk '/^Mem:/ {print $2}') - 512)" >> $GITHUB_OUTPUT
       - name: Check whether prepare script is present
         id: check-test-configured
         shell: bash
@@ -94,6 +98,8 @@ jobs:
         run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.prepare-command }} ${{ inputs.prepare-command-args }}
       - name: Run test
         run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.test-command }} ${{ inputs.test-command-args }}
+        env:
+          NODE_OPTIONS: --max-old-space-size=${{ steps.calc-system-memory.outputs.available }}
       - name: Check whether SonarCloud is configured
         id: check-sonarcloud-configured
         shell: bash
@@ -109,6 +115,8 @@ jobs:
       - name: Run SonarCloud prepare script
         if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true' && steps.check-sonarcloud-configured.outputs.sonar-prepare == 'true'
         run: ${{ steps.pkg-manager.outputs.run-cmd }} ${{ inputs.sonarcloud-command }} ${{ inputs.sonarcloud-command-args }}
+        env:
+          NODE_OPTIONS: --max-old-space-size=${{ steps.calc-system-memory.outputs.available }}
       - name: Login to Docker Hub
         if: steps.check-sonarcloud-configured.outputs.sonar-ready == 'true'
         uses: docker/login-action@v2


### PR DESCRIPTION
## Proposed Changes
- Web Checks 워크플로우에 runner에서 가용가능한 메모리를 자동으로 산정해서 node 런타임 실행시 `--max-old-space-size` 옵션을 자동으로 포함시키도록 합니다.


## Test Status
commerce-web에서 테스트를 진행합니다.
https://github.com/bucketplace/commerce-web/actions/runs/6781026879/job/18430617611 에서 잘 돌아가는 것을 확인했습니다!
