### PR TITLE
[SEARCH-2072] add mortar, non-mortar deploy action

### DIFF
--- a/.github/workflows/mortar-build-and-push-action.yaml
+++ b/.github/workflows/mortar-build-and-push-action.yaml
@@ -1,0 +1,136 @@
+name: 🚀 Mortar Build And Push Action
+
+on:
+  workflow_call:
+    inputs:
+      application:
+        required: true
+        type: string
+      profile:
+        required: true
+        type: string
+      mortar-config:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      account-type:
+        type: string
+        required: true
+      skip-update-version:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      DEV_AWS_ACCESS_KEY_ID:
+        required: true
+      DEV_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DEV_AWS_ACCOUNT_ID:
+        required: true
+      DATA_AWS_ACCESS_KEY_ID:
+        required: true
+      DATA_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DATA_AWS_ACCOUNT_ID:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_ACCOUNT_ID:
+        required: true
+      NEXUS_DEPLOY_USERPASS:
+        required: true
+      OPSMONSTER_AUTH_TOKEN_V2:
+        required: true
+      OPSMONSTER_BASE_URL_V2:
+        required: true
+    outputs:
+      version:
+        description: "The version of the application that was built and pushed"
+        value: ${{ jobs.build-and-push.outputs.version }}
+
+jobs:
+  build-and-push:
+    name: "Build: ${{ inputs.application }}"
+    runs-on: [ self-hosted, Linux, X64, mortar, v2 ]
+    env:
+      DEBUG: true
+      APP_PROFILE: ${{ inputs.profile }}
+    outputs:
+      version: ${{ steps.mortar-deploy.outputs.app-version }}
+    steps:
+      - name: Resolve AWS environment
+        id: aws
+        run: |
+          if [ "${{ inputs.account-type }}" == "DATA" ] 
+          then
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DATA_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DATA_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.account-type }}" == "DEV" ] 
+          then
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DEV_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DEV_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::${{ secrets.AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+      - name: Change mortar version
+        uses: mikefarah/yq@master
+        with:
+          cmd: >
+            yq -i
+            '.version = "${{ inputs.version }}"'
+            ${{ inputs.mortar-config }}
+      - name: Mortar Deploy
+        id: mortar-deploy
+        uses: bucketplace/mortar-deploy-action@v1
+        with:
+          aws-access-key-id: ${{ steps.aws.outputs.access_key_id }}
+          aws-secret-access-key: ${{ steps.aws.outputs.secret_access_key }}
+          aws-region: ap-northeast-2
+          nexus-user: ${{ secrets.NEXUS_DEPLOY_USERPASS }}
+          prod: ${{ inputs.profile == 'prod' }}
+          config: ${{ inputs.mortar-config }}
+          create-ecr-repo: true
+      - name: Report Summary
+        run: |
+          cat > "$GITHUB_STEP_SUMMARY" << EOF
+          ### Deployment Information
+          배포가 실행되었습니다. :rocket:
+          | Key | Value |
+          | --- | --- |
+          | Application | ${{ inputs.application }} |
+          | Environment | ${{ env.APP_PROFILE }} |
+          | Application Version | ${{ inputs.version }} |
+          | Deployed By | @${{ github.actor }} |
+          EOF
+      - name: Push commit and tag
+        if: inputs.profile == 'prod' && inputs.skip-update-version == false
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "[skip actions] Automatically update mortar.yaml version of ${{ inputs.application }} to v${{ inputs.version }}"
+          tagging_message: "${{ inputs.application }}-v${{ inputs.version }}"
+          branch: main
+          commit_user_name: bp-deployer
+          commit_user_email: bp-deployer@users.noreply.github.com
+          commit_author: bp-deployer <bp-deployer@users.noreply.github.com>

--- a/.github/workflows/mortar-deploy-action.yaml
+++ b/.github/workflows/mortar-deploy-action.yaml
@@ -1,0 +1,120 @@
+name: 🚀 Mortar Deploy Action
+
+on:
+  workflow_call:
+    inputs:
+      application:
+        description: "배포할 애플리케이션"
+        type: string
+        required: true
+      profile:
+        description: "배포 환경"
+        type: string
+        required: true
+      mortar-config:
+        description: "Mortar 설정 파일 경로"
+        type: string
+        required: true
+      update-type:
+        description: "업데이트 타입"
+        type: string
+        required: true
+      account-type:
+        type: string
+        required: true
+      skip-update-version:
+        type: boolean
+        required: false
+        default: false
+      mortar-version:
+        type: string
+        description: "mortar 버전 (JVM 17이상시 v2, 이하시 v1)"
+        required: false
+        default: "v2"
+    secrets:
+      DEV_AWS_ACCESS_KEY_ID:
+        required: true
+      DEV_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DEV_AWS_ACCOUNT_ID:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_ACCOUNT_ID:
+        required: true
+      DATA_AWS_ACCESS_KEY_ID:
+        required: true
+      DATA_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DATA_AWS_ACCOUNT_ID:
+        required: true
+      NEXUS_DEPLOY_USERPASS:
+        required: true
+      OPSMONSTER_AUTH_TOKEN_V2:
+        required: true
+      OPSMONSTER_BASE_URL_V2:
+        required: true
+
+jobs:
+  get-updated-version:
+    name: Get Updated Version
+    runs-on: [ self-hosted, Linux, X64, mortar, "${{ inputs.mortar-version }}" ]
+    env:
+      DEBUG: true
+    outputs:
+      updated-version: ${{ steps.get-tag.outputs.next-version }}
+      updated-tag: ${{ steps.get-tag.outputs.next-tag }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Get Tags
+        id: get-tag
+        uses: bucketplace/ci/.github/actions/multimodule-changelog@latest
+        with:
+          module: '${{ inputs.application }}'
+          bump: '${{ inputs.update-type }}'
+
+  mortar-build-and-push-action:
+    name: "Build and Push: ${{ inputs.application }}"
+    needs: [ get-updated-version ]
+    uses: ./.github/workflows/mortar-build-and-push-action.yaml
+    with:
+      application: ${{ inputs.application }}
+      profile: ${{ inputs.profile }}
+      mortar-config: ${{ inputs.mortar-config }}
+      version: ${{ needs.get-updated-version.outputs.updated-version }}
+      account-type: ${{ inputs.account-type }}
+      skip-update-version: ${{ inputs.skip-update-version }}
+    secrets: inherit
+
+  trigger-cd:
+    name: "Trigger CD: ${{ inputs.application }}"
+    if: inputs.skip-update-version == false
+    needs: [ mortar-build-and-push-action ]
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
+    steps:
+      - name: CD trigger
+        uses: bucketplace/cd-trigger-action@v2.1
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.application }}
+          profile: ${{ inputs.profile }}
+          image-tag: ${{ needs.mortar-build-and-push-action.outputs.version }}
+          version: ${{ needs.mortar-build-and-push-action.outputs.version }}
+
+  release-tag:
+    name: "Relase Tag: ${{ inputs.application }}"
+    if: inputs.profile == 'prod' && inputs.skip-update-version == false
+    needs: [ mortar-build-and-push-action, get-updated-version ]
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ needs.get-updated-version.outputs.updated-tag }}"
+          generateReleaseNotes: "true"
+          makeLatest: "latest"

--- a/.github/workflows/mortar-preview-action.yaml
+++ b/.github/workflows/mortar-preview-action.yaml
@@ -1,0 +1,224 @@
+name: 🚀 Mortar Preview Action
+
+on:
+  workflow_call:
+    inputs:
+      application:
+        description: "배포할 애플리케이션"
+        type: string
+        required: true
+      profile:
+        description: "배포 환경"
+        type: string
+        required: true
+      base-domain:
+        type: string
+        required: true
+      destination:
+        type: string
+        required: true
+      working-directory:
+        type: string
+        required: true
+      account-type:
+        type: string
+        required: true
+      mortar-config:
+        description: "Mortar 설정 파일 경로"
+        type: string
+        required: true
+      mortar-version:
+        type: string
+        description: "mortar 버전 (JVM 17이상시 v2, 이하시 v1)"
+        required: false
+        default: "v2"
+
+jobs:
+  check-comment:
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
+    if: github.event.action != 'closed'
+    outputs:
+      triggered: ${{ steps.check.outputs.triggered }}
+    steps:
+      - uses: bucketplace/comment-trigger@v1.0
+        id: check
+        with:
+          trigger: '/preview ${{ inputs.application }}'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+  get-updated-version:
+    name: Get Updated Version
+    runs-on: [ self-hosted, Linux, X64, mortar, "${{ inputs.mortar-version }}" ]
+    env:
+      DEBUG: true
+    outputs:
+      updated-version: ${{ steps.get-tag.outputs.next-version }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Get Tags
+        id: get-tag
+        uses: bucketplace/ci/.github/actions/multimodule-changelog@latest
+        with:
+          module: '${{ inputs.application }}'
+          bump: 'major'
+
+  build-and-push:
+    runs-on: [self-hosted, Linux, X64, mortar, v2]
+    needs: [check-comment, get-updated-version]
+    if: needs.check-comment.outputs.triggered == 'true'
+    env:
+      DEBUG: true
+      APP_PROFILE: ${{ inputs.profile }}
+    outputs:
+      version: ${{ steps.mortar-deploy.outputs.app-version }}
+    steps:
+      - name: Resolve AWS environment
+        id: aws
+        run: |
+          if [ "${{ inputs.account-type }}" == "DATA" ] 
+          then
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DATA_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DATA_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.account-type }}" == "DEV" ] 
+          then
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DEV_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DEV_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::${{ secrets.AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+      - name: get pull request ref
+        id: get_pull_request_ref
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/:repository/pulls/:issue_id
+          repository: ${{ github.repository }}
+          issue_id: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+          ref: ${{ fromJson(steps.get_pull_request_ref.outputs.data).head.ref }}
+      - name: Change mortar version
+        uses: mikefarah/yq@master
+        with:
+          cmd: >
+            yq -i
+            '.version = "${{ needs.get-updated-version.outputs.updated-version }}"'
+            ${{ inputs.mortar-config }}
+      - name: Mortar Deploy
+        id: mortar-deploy
+        uses: bucketplace/mortar-deploy-action@v1
+        with:
+          aws-access-key-id: ${{ steps.aws.outputs.access_key_id }}
+          aws-secret-access-key: ${{ steps.aws.outputs.secret_access_key }}
+          aws-region: ap-northeast-2
+          nexus-user: ${{ secrets.NEXUS_DEPLOY_USERPASS }}
+          prod: false
+          config: ${{ inputs.mortar-config }}
+          create-ecr-repo: true
+      - name: Report Summary
+        run: |
+          cat > "$GITHUB_STEP_SUMMARY" << EOF
+          ### Deployment Information
+          배포가 실행되었습니다. :rocket:
+          | Key | Value |
+          | --- | --- |
+          | Application | ${{ inputs.application }} |
+          | Environment | ${{ env.APP_PROFILE }} |
+          | Application Version | ${{ needs.get-updated-version.outputs.updated-version }} |
+          | Deployed By | @${{ github.actor }} |
+          EOF
+
+  get-metadata:
+    runs-on: [self-hosted, Linux, X64, cache]
+    needs: check-comment
+    if: needs.check-comment.outputs.triggered == 'true'
+    outputs:
+      pr_ref: ${{ fromJson(steps.get_pull_request_ref.outputs.data).head.ref }}
+      pr_title: ${{ fromJson(steps.get_pull_request_ref.outputs.data).title }}
+      pr_url: ${{ fromJson(steps.get_pull_request_ref.outputs.data).html_url }}
+      pr_assignee: ${{ fromJson(steps.get_pull_request_ref.outputs.data).assignee.login }}
+    steps:
+      - name: get pull request ref
+        id: get_pull_request_ref
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/:repository/pulls/:issue_id
+          repository: ${{ github.repository }}
+          issue_id: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  preview-request:
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
+    needs: [get-metadata, build-and-push]
+    steps:
+      - name: Preview request
+        id: pr
+        uses: bucketplace/preview-request-action@v2.1.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.APPLICATION }}
+          branch: ${{ needs.get-metadata.outputs.pr_ref }}
+          release-name-length: 40
+          pr-title: ${{ needs.get-metadata.outputs.pr_title }}
+          pr-url: ${{ needs.get-metadata.outputs.pr_url }}
+          pr-assignee: ${{ needs.get-metadata.outputs.pr_assignee }}
+          profile: ${{ inputs.profile }}
+          image-tag: ${{ needs.build-and-push.outputs.version }}
+          base-domain: ${{ inputs.base-domain }}
+          destination: ${{ inputs.destination }}
+      - name: Comment on PR
+        uses: bucketplace/pull-request-add-comment-action@main
+        with:
+          message: |-
+            🚀 preview endpoint 가 생성되었습니다. [link](https://${{ steps.pr.outputs.endpoint }})
+            ```
+            https://${{ steps.pr.outputs.endpoint }}
+            ```
+            🎁 preview context
+            ```json
+            ${{ steps.pr.outputs.context }}
+            ```
+          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+      - if: ${{ failure() }}
+        uses: bucketplace/pull-request-add-comment-action@main
+        with:
+          message: |-
+            preview 배포 실패
+          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+
+  clean-up-preview:
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
+    if: github.event.action == 'closed'
+    steps:
+      - name: Clean up preview resources
+        uses: bucketplace/preview-delete-action@v2.1.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.APPLICATION }}
+          branch: ${{ github.head_ref }}
+          release-name-length: 40

--- a/.github/workflows/non-mortar-build-and-push-action.yaml
+++ b/.github/workflows/non-mortar-build-and-push-action.yaml
@@ -1,0 +1,134 @@
+name: 🚀 Non Mortar Deploy Action
+
+on:
+  workflow_call:
+    inputs:
+      application:
+        description: "배포할 애플리케이션"
+        type: string
+        required: true
+      profile:
+        description: "배포 환경"
+        type: string
+        required: true
+      update-type:
+        description: "업데이트 타입"
+        type: string
+        required: true
+      account-type:
+        type: string
+        required: true
+      ecr-repository:
+        type: string
+        required: true
+      dockerfile:
+        type: string
+        required: true
+      working-directory:
+        type: string
+        required: true
+      skip-update-version:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      DEV_AWS_ACCESS_KEY_ID:
+        required: true
+      DEV_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DEV_AWS_ACCOUNT_ID:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_ACCOUNT_ID:
+        required: true
+      DATA_AWS_ACCESS_KEY_ID:
+        required: true
+      DATA_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DATA_AWS_ACCOUNT_ID:
+        required: true
+      NEXUS_DEPLOY_USERPASS:
+        required: true
+      OPSMONSTER_AUTH_TOKEN_V2:
+        required: true
+      OPSMONSTER_BASE_URL_V2:
+        required: true
+
+jobs:
+  get-updated-version:
+    name: Get Updated Version
+    runs-on: [ self-hosted, Linux, X64, mortar, v2 ]
+    env:
+      DEBUG: true
+    outputs:
+      updated-version: ${{ steps.set-updated.outputs.updated-version }}
+      updated-tag: ${{ steps.get-tag.outputs.next-tag }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: get short git sha
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Get Tags
+        id: get-tag
+        uses: bucketplace/ci/.github/actions/multimodule-changelog@latest
+        with:
+          module: '${{ inputs.application }}'
+          bump: '${{ inputs.update-type }}'
+      - name: Set Updated
+        id: set-updated
+        run: |
+          if [[ "${{ inputs.profile }}" != "prod" ]]; then
+            echo "updated-version=${{ steps.get-tag.outputs.next-version }}-${{ steps.vars.outputs.sha_short }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated-version=${{ steps.get-tag.outputs.next-version }}" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+  non-mortar-build-and-push-action:
+    name: "Build and Push: ${{ inputs.application }}"
+    needs: [ get-updated-version ]
+    uses: ./.github/workflows/non-mortar-build-and-push-action.yaml
+    with:
+      application: ${{ inputs.application }}
+      profile: ${{ inputs.profile }}
+      version: ${{ needs.get-updated-version.outputs.updated-version }}
+      account-type: ${{ inputs.account-type }}
+      ecr-repository: ${{ inputs.ecr-repository }}
+      dockerfile: ${{ inputs.dockerfile }}
+      working-directory: ${{ inputs.working-directory }}
+      skip-update-version: ${{ inputs.skip-update-version }}
+    secrets: inherit
+
+  trigger-cd:
+    name: "Trigger CD: ${{ inputs.application }}"
+    if: inputs.skip-update-version == false
+    needs: [ non-mortar-build-and-push-action ]
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
+    steps:
+      - name: CD trigger
+        uses: bucketplace/cd-trigger-action@v2.1
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.application }}
+          profile: ${{ inputs.profile }}
+          image-tag: ${{ needs.non-mortar-build-and-push-action.outputs.version }}
+          version: ${{ needs.non-mortar-build-and-push-action.outputs.version }}
+
+  release-tag:
+    name: "Relase Tag: ${{ inputs.application }}"
+    if: inputs.profile == 'prod' && inputs.skip-update-version == false
+    needs: [ non-mortar-build-and-push-action, get-updated-version ]
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ needs.get-updated-version.outputs.updated-tag }}"
+          generateReleaseNotes: "true"
+          makeLatest: "latest"

--- a/.github/workflows/non-mortar-build-and-push-action.yaml
+++ b/.github/workflows/non-mortar-build-and-push-action.yaml
@@ -1,20 +1,17 @@
-name: 🚀 Non Mortar Deploy Action
+name: 🚀 Non Mortar Build And Push Action
 
 on:
   workflow_call:
     inputs:
       application:
-        description: "배포할 애플리케이션"
-        type: string
         required: true
+        type: string
       profile:
-        description: "배포 환경"
-        type: string
         required: true
-      update-type:
-        description: "업데이트 타입"
         type: string
+      version:
         required: true
+        type: string
       account-type:
         type: string
         required: true
@@ -38,17 +35,17 @@ on:
         required: true
       DEV_AWS_ACCOUNT_ID:
         required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      AWS_ACCOUNT_ID:
-        required: true
       DATA_AWS_ACCESS_KEY_ID:
         required: true
       DATA_AWS_SECRET_ACCESS_KEY:
         required: true
       DATA_AWS_ACCOUNT_ID:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_ACCOUNT_ID:
         required: true
       NEXUS_DEPLOY_USERPASS:
         required: true
@@ -56,79 +53,75 @@ on:
         required: true
       OPSMONSTER_BASE_URL_V2:
         required: true
+    outputs:
+      version:
+        description: "The version of the application that was built and pushed"
+        value: ${{ jobs.build-and-push.outputs.version }}
 
 jobs:
-  get-updated-version:
-    name: Get Updated Version
+  build-and-push:
+    name: "Build: ${{ inputs.application }}"
     runs-on: [ self-hosted, Linux, X64, mortar, v2 ]
     env:
       DEBUG: true
+      APP_PROFILE: ${{ inputs.profile }}
     outputs:
-      updated-version: ${{ steps.set-updated.outputs.updated-version }}
-      updated-tag: ${{ steps.get-tag.outputs.next-tag }}
+      version: ${{ inputs.version }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: get short git sha
-        id: vars
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Get Tags
-        id: get-tag
-        uses: bucketplace/ci/.github/actions/multimodule-changelog@latest
-        with:
-          module: '${{ inputs.application }}'
-          bump: '${{ inputs.update-type }}'
-      - name: Set Updated
-        id: set-updated
+      - name: Resolve AWS environment
+        id: aws
         run: |
-          if [[ "${{ inputs.profile }}" != "prod" ]]; then
-            echo "updated-version=${{ steps.get-tag.outputs.next-version }}-${{ steps.vars.outputs.sha_short }}" >> "$GITHUB_OUTPUT"
+          if [ "${{ inputs.account-type }}" == "DATA" ] 
+          then
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DATA_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DATA_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.account-type }}" == "DEV" ] 
+          then
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DEV_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DEV_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
           else
-            echo "updated-version=${{ steps.get-tag.outputs.next-version }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
-
-  non-mortar-build-and-push-action:
-    name: "Build and Push: ${{ inputs.application }}"
-    needs: [ get-updated-version ]
-    uses: ./.github/workflows/non-mortar-build-and-push-action.yaml
-    with:
-      application: ${{ inputs.application }}
-      profile: ${{ inputs.profile }}
-      version: ${{ needs.get-updated-version.outputs.updated-version }}
-      account-type: ${{ inputs.account-type }}
-      ecr-repository: ${{ inputs.ecr-repository }}
-      dockerfile: ${{ inputs.dockerfile }}
-      working-directory: ${{ inputs.working-directory }}
-      skip-update-version: ${{ inputs.skip-update-version }}
-    secrets: inherit
-
-  trigger-cd:
-    name: "Trigger CD: ${{ inputs.application }}"
-    if: inputs.skip-update-version == false
-    needs: [ non-mortar-build-and-push-action ]
-    runs-on: [ self-hosted, Linux, X64, no-cache ]
-    steps:
-      - name: CD trigger
-        uses: bucketplace/cd-trigger-action@v2.1
-        env:
-          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
-          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+      - name: Check out code
+        uses: actions/checkout@v3
         with:
-          application: ${{ inputs.application }}
-          profile: ${{ inputs.profile }}
-          image-tag: ${{ needs.non-mortar-build-and-push-action.outputs.version }}
-          version: ${{ needs.non-mortar-build-and-push-action.outputs.version }}
-
-  release-tag:
-    name: "Relase Tag: ${{ inputs.application }}"
-    if: inputs.profile == 'prod' && inputs.skip-update-version == false
-    needs: [ non-mortar-build-and-push-action, get-updated-version ]
-    runs-on: [ self-hosted, Linux, X64, no-cache ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ncipollo/release-action@v1
+          token: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+      - name: Non Mortar Deploy
+        uses: kciter/aws-ecr-action@master
         with:
-          tag: "${{ needs.get-updated-version.outputs.updated-tag }}"
-          generateReleaseNotes: "true"
-          makeLatest: "latest"
+          access_key_id: ${{ steps.aws.outputs.access_key_id }}
+          secret_access_key: ${{ steps.aws.outputs.secret_access_key }}
+          account_id: "${{ steps.aws.outputs.account_id }}"
+          repo: ${{ inputs.ecr-repository }}
+          region: ap-northeast-2
+          tags: ${{ inputs.version }}
+          create_repo: true
+          path: ${{ inputs.working-directory }}
+          dockerfile: ${{ inputs.dockerfile }}
+          extra_build_args: "--target app --build-arg ACCESS_TOKEN=${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}"
+      - name: Report Summary
+        run: |
+          cat > "$GITHUB_STEP_SUMMARY" << EOF
+          ### Deployment Information
+          배포가 실행되었습니다. :rocket:
+          | Key | Value |
+          | --- | --- |
+          | Application | ${{ inputs.application }} |
+          | Environment | ${{ env.APP_PROFILE }} |
+          | Application Version | ${{ inputs.version }} |
+          | Deployed By | @${{ github.actor }} |
+          EOF

--- a/.github/workflows/non-mortar-deploy-action.yaml
+++ b/.github/workflows/non-mortar-deploy-action.yaml
@@ -1,4 +1,4 @@
-name: 🚀 Non Mortar Preview Action
+name: 🚀 Non Mortar Deploy Action
 
 on:
   workflow_call:
@@ -11,182 +11,124 @@ on:
         description: "배포 환경"
         type: string
         required: true
-      ecr-repository:
-        type: string
-        required: true
-      base-domain:
-        type: string
-        required: true
-      destination:
-        type: string
-        required: true
-      working-directory:
+      update-type:
+        description: "업데이트 타입"
         type: string
         required: true
       account-type:
         type: string
         required: true
+      ecr-repository:
+        type: string
+        required: true
+      dockerfile:
+        type: string
+        required: true
+      working-directory:
+        type: string
+        required: true
+      skip-update-version:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      DEV_AWS_ACCESS_KEY_ID:
+        required: true
+      DEV_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DEV_AWS_ACCOUNT_ID:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_ACCOUNT_ID:
+        required: true
+      DATA_AWS_ACCESS_KEY_ID:
+        required: true
+      DATA_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DATA_AWS_ACCOUNT_ID:
+        required: true
+      NEXUS_DEPLOY_USERPASS:
+        required: true
+      OPSMONSTER_AUTH_TOKEN_V2:
+        required: true
+      OPSMONSTER_BASE_URL_V2:
+        required: true
 
 jobs:
-  check-comment:
-    runs-on: [self-hosted, Linux, X64, no-cache]
-    if: github.event.action != 'closed'
+  get-updated-version:
+    name: Get Updated Version
+    runs-on: [ self-hosted, Linux, X64, mortar, v2 ]
+    env:
+      DEBUG: true
     outputs:
-      triggered: ${{ steps.check.outputs.triggered }}
+      updated-version: ${{ steps.set-updated.outputs.updated-version }}
+      updated-tag: ${{ steps.get-tag.outputs.next-tag }}
     steps:
-      - uses: bucketplace/comment-trigger@v1.0
-        id: check
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: get short git sha
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Get Tags
+        id: get-tag
+        uses: bucketplace/ci/.github/actions/multimodule-changelog@latest
         with:
-          trigger: '/preview ${{ inputs.application }}'
-          reaction: rocket
-        env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-
-  build-and-push:
-    runs-on: [self-hosted, Linux, X64, cache]
-    needs: check-comment
-    if: needs.check-comment.outputs.triggered == 'true'
-    outputs:
-      image_tag: ${{ steps.vars.outputs.image_tag }}
-      pr_ref: ${{ fromJson(steps.get_pull_request_ref.outputs.data).head.ref }}
-      pr_title: ${{ fromJson(steps.get_pull_request_ref.outputs.data).title }}
-      pr_url: ${{ fromJson(steps.get_pull_request_ref.outputs.data).html_url }}
-      pr_assignee: ${{ fromJson(steps.get_pull_request_ref.outputs.data).assignee.login }}
-    steps:
-      - name: Resolve AWS environment
-        id: aws
+          module: '${{ inputs.application }}'
+          bump: '${{ inputs.update-type }}'
+      - name: Set Updated
+        id: set-updated
         run: |
-          if [ "${{ inputs.account-type }}" == "DATA" ] 
-          then
-            echo "::add-mask::${{ secrets.DATA_AWS_ACCESS_KEY_ID }}"
-            echo "access_key_id=${{ secrets.DATA_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
-            echo "::add-mask::${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}"
-            echo "secret_access_key=${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
-            echo "::add-mask::${{ secrets.DATA_AWS_ACCOUNT_ID }}"
-            echo "account_id=${{ secrets.DATA_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ inputs.account-type }}" == "DEV" ] 
-          then
-            echo "::add-mask::${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
-            echo "access_key_id=${{ secrets.DEV_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
-            echo "::add-mask::${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
-            echo "secret_access_key=${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
-            echo "::add-mask::${{ secrets.DEV_AWS_ACCOUNT_ID }}"
-            echo "account_id=${{ secrets.DEV_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          if [[ "${{ inputs.profile }}" != "prod" ]]; then
+            echo "updated-version=${{ steps.get-tag.outputs.next-version }}-${{ steps.vars.outputs.sha_short }}" >> "$GITHUB_OUTPUT"
           else
-            echo "::add-mask::${{ secrets.AWS_ACCESS_KEY_ID }}"
-            echo "access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
-            echo "::add-mask::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-            echo "secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
-            echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
-            echo "account_id=${{ secrets.AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+            echo "updated-version=${{ steps.get-tag.outputs.next-version }}" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
-      - name: get pull request ref
-        id: get_pull_request_ref
-        uses: octokit/request-action@v2.x
-        with:
-          route: GET /repos/:repository/pulls/:issue_id
-          repository: ${{ github.repository }}
-          issue_id: ${{ github.event.issue.number }}
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ fromJson(steps.get_pull_request_ref.outputs.data).head.ref }}
+  non-mortar-build-and-push-action:
+    name: "Build and Push: ${{ inputs.application }}"
+    needs: [ get-updated-version ]
+    uses: ./.github/workflows/non-mortar-build-and-push-action.yaml
+    with:
+      application: ${{ inputs.application }}
+      profile: ${{ inputs.profile }}
+      version: ${{ needs.get-updated-version.outputs.updated-version }}
+      account-type: ${{ inputs.account-type }}
+      ecr-repository: ${{ inputs.ecr-repository }}
+      dockerfile: ${{ inputs.dockerfile }}
+      working-directory: ${{ inputs.working-directory }}
+      skip-update-version: ${{ inputs.skip-update-version }}
+    secrets: inherit
 
-      - name: Get image tag
-        id: vars
-        run: echo "image_tag=preview-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ steps.aws.outputs.access_key_id }}
-          aws-secret-access-key: ${{ steps.aws.outputs.secret_access_key }}
-          aws-region: ap-northeast-2
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build, tag, and push image to Amazon ECR
-        id: build-image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ steps.vars.outputs.image_tag }}
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
-          ECR_REPOSITORY: ${{ inputs.ecr-repository }}
-        run: |
-          # Build a docker container and
-          # push it to ECR so that it can
-          # be deployed to ECS.
-          docker build \
-            --target app \
-            --build-arg ACCESS_TOKEN=${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }} \
-            -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
-            -f "$WORKING_DIRECTORY/Dockerfile" \
-            -- "./$WORKING_DIRECTORY"
-          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-      - if: ${{ failure() }}
-        uses: bucketplace/pull-request-add-comment-action@main
-        with:
-          message: |-
-            preview 배포 실패
-          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
-
-  preview-request:
-    runs-on: [self-hosted, Linux, X64, no-cache]
-    needs: build-and-push
+  trigger-cd:
+    name: "Trigger CD: ${{ inputs.application }}"
+    if: inputs.skip-update-version == false
+    needs: [ non-mortar-build-and-push-action ]
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
     steps:
-      - name: Preview request
-        id: pr
-        uses: bucketplace/preview-request-action@v2.1.0
+      - name: CD trigger
+        uses: bucketplace/cd-trigger-action@v2.1
         env:
           AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
           BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
         with:
-          application: ${{ inputs.APPLICATION }}
-          branch: ${{ needs.build-and-push.outputs.pr_ref }}
-          release-name-length: 40
-          pr-title: ${{ needs.build-and-push.outputs.pr_title }}
-          pr-url: ${{ needs.build-and-push.outputs.pr_url }}
-          pr-assignee: ${{ needs.build-and-push.outputs.pr_assignee }}
+          application: ${{ inputs.application }}
           profile: ${{ inputs.profile }}
-          image-tag: ${{ needs.build-and-push.outputs.image_tag }}
-          base-domain: ${{ inputs.base-domain }}
-          destination: ${{ inputs.destination }}
-      - name: Comment on PR
-        uses: bucketplace/pull-request-add-comment-action@main
-        with:
-          message: |-
-            🚀 preview endpoint 가 생성되었습니다. [link](https://${{ steps.pr.outputs.endpoint }})
-            ```
-            https://${{ steps.pr.outputs.endpoint }}
-            ```
-            🎁 preview context
-            ```json
-            ${{ steps.pr.outputs.context }}
-            ```
-          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
-      - if: ${{ failure() }}
-        uses: bucketplace/pull-request-add-comment-action@main
-        with:
-          message: |-
-            preview 배포 실패
-          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+          image-tag: ${{ needs.non-mortar-build-and-push-action.outputs.version }}
+          version: ${{ needs.non-mortar-build-and-push-action.outputs.version }}
 
-  clean-up-preview:
-    runs-on: [self-hosted, Linux, X64, no-cache]
-    if: github.event.action == 'closed'
+  release-tag:
+    name: "Relase Tag: ${{ inputs.application }}"
+    if: inputs.profile == 'prod' && inputs.skip-update-version == false
+    needs: [ non-mortar-build-and-push-action, get-updated-version ]
+    runs-on: [ self-hosted, Linux, X64, no-cache ]
     steps:
-      - name: Clean up preview resources
-        uses: bucketplace/preview-delete-action@v2.1.0
-        env:
-          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
-          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+      - uses: actions/checkout@v3
+      - uses: ncipollo/release-action@v1
         with:
-          application: ${{ inputs.APPLICATION }}
-          branch: ${{ github.head_ref }}
-          release-name-length: 40
+          tag: "${{ needs.get-updated-version.outputs.updated-tag }}"
+          generateReleaseNotes: "true"
+          makeLatest: "latest"

--- a/.github/workflows/non-mortar-deploy-action.yaml
+++ b/.github/workflows/non-mortar-deploy-action.yaml
@@ -1,0 +1,192 @@
+name: 🚀 Non Mortar Preview Action
+
+on:
+  workflow_call:
+    inputs:
+      application:
+        description: "배포할 애플리케이션"
+        type: string
+        required: true
+      profile:
+        description: "배포 환경"
+        type: string
+        required: true
+      ecr-repository:
+        type: string
+        required: true
+      base-domain:
+        type: string
+        required: true
+      destination:
+        type: string
+        required: true
+      working-directory:
+        type: string
+        required: true
+      account-type:
+        type: string
+        required: true
+
+jobs:
+  check-comment:
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    if: github.event.action != 'closed'
+    outputs:
+      triggered: ${{ steps.check.outputs.triggered }}
+    steps:
+      - uses: bucketplace/comment-trigger@v1.0
+        id: check
+        with:
+          trigger: '/preview ${{ inputs.application }}'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+  build-and-push:
+    runs-on: [self-hosted, Linux, X64, cache]
+    needs: check-comment
+    if: needs.check-comment.outputs.triggered == 'true'
+    outputs:
+      image_tag: ${{ steps.vars.outputs.image_tag }}
+      pr_ref: ${{ fromJson(steps.get_pull_request_ref.outputs.data).head.ref }}
+      pr_title: ${{ fromJson(steps.get_pull_request_ref.outputs.data).title }}
+      pr_url: ${{ fromJson(steps.get_pull_request_ref.outputs.data).html_url }}
+      pr_assignee: ${{ fromJson(steps.get_pull_request_ref.outputs.data).assignee.login }}
+    steps:
+      - name: Resolve AWS environment
+        id: aws
+        run: |
+          if [ "${{ inputs.account-type }}" == "DATA" ] 
+          then
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DATA_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DATA_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.account-type }}" == "DEV" ] 
+          then
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DEV_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DEV_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::${{ secrets.AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+      - name: get pull request ref
+        id: get_pull_request_ref
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/:repository/pulls/:issue_id
+          repository: ${{ github.repository }}
+          issue_id: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ fromJson(steps.get_pull_request_ref.outputs.data).head.ref }}
+
+      - name: Get image tag
+        id: vars
+        run: echo "image_tag=preview-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ steps.aws.outputs.access_key_id }}
+          aws-secret-access-key: ${{ steps.aws.outputs.secret_access_key }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.image_tag }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+        run: |
+          # Build a docker container and
+          # push it to ECR so that it can
+          # be deployed to ECS.
+          docker build \
+            --target app \
+            --build-arg ACCESS_TOKEN=${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }} \
+            -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            -f "$WORKING_DIRECTORY/Dockerfile" \
+            -- "./$WORKING_DIRECTORY"
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+      - if: ${{ failure() }}
+        uses: bucketplace/pull-request-add-comment-action@main
+        with:
+          message: |-
+            preview 배포 실패
+          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+
+  preview-request:
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    needs: build-and-push
+    steps:
+      - name: Preview request
+        id: pr
+        uses: bucketplace/preview-request-action@v2.1.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.APPLICATION }}
+          branch: ${{ needs.build-and-push.outputs.pr_ref }}
+          release-name-length: 40
+          pr-title: ${{ needs.build-and-push.outputs.pr_title }}
+          pr-url: ${{ needs.build-and-push.outputs.pr_url }}
+          pr-assignee: ${{ needs.build-and-push.outputs.pr_assignee }}
+          profile: ${{ inputs.profile }}
+          image-tag: ${{ needs.build-and-push.outputs.image_tag }}
+          base-domain: ${{ inputs.base-domain }}
+          destination: ${{ inputs.destination }}
+      - name: Comment on PR
+        uses: bucketplace/pull-request-add-comment-action@main
+        with:
+          message: |-
+            🚀 preview endpoint 가 생성되었습니다. [link](https://${{ steps.pr.outputs.endpoint }})
+            ```
+            https://${{ steps.pr.outputs.endpoint }}
+            ```
+            🎁 preview context
+            ```json
+            ${{ steps.pr.outputs.context }}
+            ```
+          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+      - if: ${{ failure() }}
+        uses: bucketplace/pull-request-add-comment-action@main
+        with:
+          message: |-
+            preview 배포 실패
+          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+
+  clean-up-preview:
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    if: github.event.action == 'closed'
+    steps:
+      - name: Clean up preview resources
+        uses: bucketplace/preview-delete-action@v2.1.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.APPLICATION }}
+          branch: ${{ github.head_ref }}
+          release-name-length: 40

--- a/.github/workflows/non-mortar-preview-action.yaml
+++ b/.github/workflows/non-mortar-preview-action.yaml
@@ -1,0 +1,192 @@
+name: 🚀 Non Mortar Preview Action
+
+on:
+  workflow_call:
+    inputs:
+      application:
+        description: "배포할 애플리케이션"
+        type: string
+        required: true
+      profile:
+        description: "배포 환경"
+        type: string
+        required: true
+      ecr-repository:
+        type: string
+        required: true
+      base-domain:
+        type: string
+        required: true
+      destination:
+        type: string
+        required: true
+      working-directory:
+        type: string
+        required: true
+      account-type:
+        type: string
+        required: true
+
+jobs:
+  check-comment:
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    if: github.event.action != 'closed'
+    outputs:
+      triggered: ${{ steps.check.outputs.triggered }}
+    steps:
+      - uses: bucketplace/comment-trigger@v1.0
+        id: check
+        with:
+          trigger: '/preview ${{ inputs.application }}'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+  build-and-push:
+    runs-on: [self-hosted, Linux, X64, cache]
+    needs: check-comment
+    if: needs.check-comment.outputs.triggered == 'true'
+    outputs:
+      image_tag: ${{ steps.vars.outputs.image_tag }}
+      pr_ref: ${{ fromJson(steps.get_pull_request_ref.outputs.data).head.ref }}
+      pr_title: ${{ fromJson(steps.get_pull_request_ref.outputs.data).title }}
+      pr_url: ${{ fromJson(steps.get_pull_request_ref.outputs.data).html_url }}
+      pr_assignee: ${{ fromJson(steps.get_pull_request_ref.outputs.data).assignee.login }}
+    steps:
+      - name: Resolve AWS environment
+        id: aws
+        run: |
+          if [ "${{ inputs.account-type }}" == "DATA" ] 
+          then
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DATA_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DATA_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DATA_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DATA_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.account-type }}" == "DEV" ] 
+          then
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.DEV_AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.DEV_AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.DEV_AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::${{ secrets.AWS_ACCESS_KEY_ID }}"
+            echo "access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            echo "secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${{ secrets.AWS_ACCOUNT_ID }}"
+            echo "account_id=${{ secrets.AWS_ACCOUNT_ID }}" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+      - name: get pull request ref
+        id: get_pull_request_ref
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/:repository/pulls/:issue_id
+          repository: ${{ github.repository }}
+          issue_id: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ fromJson(steps.get_pull_request_ref.outputs.data).head.ref }}
+
+      - name: Get image tag
+        id: vars
+        run: echo "image_tag=preview-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ steps.aws.outputs.access_key_id }}
+          aws-secret-access-key: ${{ steps.aws.outputs.secret_access_key }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.image_tag }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+        run: |
+          # Build a docker container and
+          # push it to ECR so that it can
+          # be deployed to ECS.
+          docker build \
+            --target app \
+            --build-arg ACCESS_TOKEN=${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }} \
+            -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            -f "$WORKING_DIRECTORY/Dockerfile" \
+            -- "./$WORKING_DIRECTORY"
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+      - if: ${{ failure() }}
+        uses: bucketplace/pull-request-add-comment-action@main
+        with:
+          message: |-
+            preview 배포 실패
+          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+
+  preview-request:
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    needs: build-and-push
+    steps:
+      - name: Preview request
+        id: pr
+        uses: bucketplace/preview-request-action@v2.1.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.APPLICATION }}
+          branch: ${{ needs.build-and-push.outputs.pr_ref }}
+          release-name-length: 40
+          pr-title: ${{ needs.build-and-push.outputs.pr_title }}
+          pr-url: ${{ needs.build-and-push.outputs.pr_url }}
+          pr-assignee: ${{ needs.build-and-push.outputs.pr_assignee }}
+          profile: ${{ inputs.profile }}
+          image-tag: ${{ needs.build-and-push.outputs.image_tag }}
+          base-domain: ${{ inputs.base-domain }}
+          destination: ${{ inputs.destination }}
+      - name: Comment on PR
+        uses: bucketplace/pull-request-add-comment-action@main
+        with:
+          message: |-
+            🚀 preview endpoint 가 생성되었습니다. [link](https://${{ steps.pr.outputs.endpoint }})
+            ```
+            https://${{ steps.pr.outputs.endpoint }}
+            ```
+            🎁 preview context
+            ```json
+            ${{ steps.pr.outputs.context }}
+            ```
+          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+      - if: ${{ failure() }}
+        uses: bucketplace/pull-request-add-comment-action@main
+        with:
+          message: |-
+            preview 배포 실패
+          GITHUB_TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+
+  clean-up-preview:
+    runs-on: [self-hosted, Linux, X64, no-cache]
+    if: github.event.action == 'closed'
+    steps:
+      - name: Clean up preview resources
+        uses: bucketplace/preview-delete-action@v2.1.0
+        env:
+          AUTH_TOKEN: ${{ secrets.OPSMONSTER_AUTH_TOKEN_V2 }}
+          BASE_URL: ${{ secrets.OPSMONSTER_BASE_URL_V2 }}
+        with:
+          application: ${{ inputs.APPLICATION }}
+          branch: ${{ github.head_ref }}
+          release-name-length: 40


### PR DESCRIPTION
## Proposed Changes
- https://github.com/bucketplace/search-backend 에서 모노레포로 전환하면서 여러 서버에서 사용할 수 있는 배포 action을 만들었는데(광고팀 모노레포 action 참고해서),
- 생각해보니 저희 검색팀 다른 레포 혹은 다른팀 에서도 다같이 사용할 수 있으면 좋을 것 같아서 추가합니다.
- 사용예시는 https://github.com/bucketplace/search-backend/blob/d3ea18ab6812faf86b5aa6a13564fab4274ebd9b/.github/workflows/search-application-server-deploy.yaml#L1 여기 보면 됩니다.


## Test Status
(테스트를 어떻게 진행했는지 설명합니다.)
