### PR TITLE
[COREPL-1535] Add protolint in ci repo to use widely

### DIFF
--- a/.github/workflows/.protolint.yaml
+++ b/.github/workflows/.protolint.yaml
@@ -1,0 +1,27 @@
+# https://github.com/yoheimuta/protolint/blob/master/_example/config/.protolint.yaml
+lint:
+  # Linter rules.
+  # Run `protolint list` to see all available rules.
+  rules:
+    # The specific linters to remove.
+    add:
+      - FILE_NAMES_LOWER_SNAKE_CASE
+      - PACKAGE_NAME_LOWER_CASE
+      - IMPORTS_SORTED
+      - ORDER
+      - FIELD_NAMES_LOWER_SNAKE_CASE
+      - REPEATED_FIELD_NAMES_PLURALIZED
+      - MESSAGE_NAMES_UPPER_CAMEL_CASE
+      - SERVICES_HAVE_COMMENT
+      - MAX_LINE_LENGTH
+      - INDENT
+      - RPCS_HAVE_COMMENT
+      - ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+      - ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  # Linter rules option.
+  rules_option:
+    max_line_length:
+      # Enforces a maximum line length
+      max_chars: 120
+      # Specifies the character count for tab characters
+      tab_chars: 2

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -2,12 +2,6 @@ name: "Check Protobuf Lint"
 
 on:
   workflow_call:
-    inputs:
-      config-path:
-        type: string
-        description: "config path of proto lint"
-        required: false
-        default: ".protolint.yaml"
     secrets:
       BP_DEPLOYER_GITHUB_TOKEN: # if you need private github module access
         required: false
@@ -26,4 +20,4 @@ jobs:
           git config --global url."https://bp-deployer:${TOKEN}@github.com/bucketplace/".insteadOf "https://github.com/bucketplace/"
       - uses: yoheimuta/action-protolint@v1
         with:
-          protolint_flags: -config_path=${{ inputs.config-path }}
+          protolint_flags: -config_path=.github/protolint.yaml

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -23,6 +23,5 @@ jobs:
           workdir: ${{ inputs.app-path }}
           protolint_flags: -config_path=.protolint.yaml
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Change reporter level if you need.
-          # GitHub Status Check won't become failure with warning.
+          fail_on_error: true
           level: error

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -2,18 +2,22 @@ name: "Check Protobuf Lint"
 
 on:
   workflow_call:
-    inputs:
-      app-name:
-        description: "sonarqube 프로젝트를 선택을 위한 앱 이름"
-        required: true
-        type: string
-
+    secrets:
+      BP_DEPLOYER_GITHUB_TOKEN: # if you need private github module access
+        required: false
 jobs:
   protolint:
     name: protolint
     runs-on: [ self-hosted, Linux, X64, cache ]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Granting private modules access
+        env:
+          TOKEN: ${{ secrets.BP_DEPLOYER_GITHUB_TOKEN }}
+        if: env.TOKEN != null
+        run: |
+          git config --global url."https://bp-deployer:${TOKEN}@github.com/bucketplace/".insteadOf "https://github.com/bucketplace/"
       - uses: yoheimuta/action-protolint@v1
         with:
           protolint_flags: -config_path=.protolint.yaml

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -1,0 +1,14 @@
+name: "Check Protobuf Lint"
+on:
+  pull_request:
+    paths:
+      - '**/*.proto'
+jobs:
+  protolint:
+    name: protolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: yoheimuta/action-protolint@v1
+        with:
+          protolint_flags: -config_path=.protolint.yaml

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -20,10 +20,8 @@ jobs:
           git config --global url."https://bp-deployer:${TOKEN}@github.com/bucketplace/".insteadOf "https://github.com/bucketplace/"
       - uses: yoheimuta/action-protolint@v1
         with:
-          protolint_flags: -config_path=.github/protolint.yaml
+          workdir: ${{ inputs.app-path }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
-          reporter: github-pr-review
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with warning.
           level: warning

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -2,11 +2,16 @@ name: "Check Protobuf Lint"
 
 on:
   workflow_call:
+    inputs:
+      app-name:
+        description: "sonarqube 프로젝트를 선택을 위한 앱 이름"
+        required: true
+        type: string
 
 jobs:
   protolint:
     name: protolint
-    runs-on: [self-hosted, Linux, X64, cache]
+    runs-on: [ self-hosted, Linux, X64, cache ]
     steps:
       - uses: actions/checkout@v4
       - uses: yoheimuta/action-protolint@v1

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -2,6 +2,12 @@ name: "Check Protobuf Lint"
 
 on:
   workflow_call:
+    inputs:
+      config-path:
+        type: string
+        description: "config path of proto lint"
+        required: false
+        default: ".protolint.yaml"
     secrets:
       BP_DEPLOYER_GITHUB_TOKEN: # if you need private github module access
         required: false
@@ -20,4 +26,4 @@ jobs:
           git config --global url."https://bp-deployer:${TOKEN}@github.com/bucketplace/".insteadOf "https://github.com/bucketplace/"
       - uses: yoheimuta/action-protolint@v1
         with:
-          protolint_flags: -config_path=.protolint.yaml
+          protolint_flags: -config_path=${{ inputs.config-path }}

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -21,3 +21,9 @@ jobs:
       - uses: yoheimuta/action-protolint@v1
         with:
           protolint_flags: -config_path=.github/protolint.yaml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
+          reporter: github-pr-review
+          # Change reporter level if you need.
+          # GitHub Status Check won't become failure with warning.
+          level: warning

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: yoheimuta/action-protolint@v1
         with:
           workdir: ${{ inputs.app-path }}
+          protolint_flags: -config_path=.protolint.yaml
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with warning.

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -1,12 +1,12 @@
 name: "Check Protobuf Lint"
+
 on:
-  pull_request:
-    paths:
-      - '**/*.proto'
+  workflow_call:
+
 jobs:
   protolint:
     name: protolint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, cache]
     steps:
       - uses: actions/checkout@v4
       - uses: yoheimuta/action-protolint@v1

--- a/.github/workflows/check-protolint.yaml
+++ b/.github/workflows/check-protolint.yaml
@@ -24,4 +24,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with warning.
-          level: warning
+          level: error


### PR DESCRIPTION
## Proposed Changes
* protolint 가 다양하게 쓰이고 하나의 repo 안에서 rule 관리하기 위해 만듭니다. 


## Test Status
* auth 에서 테스트 완료 (https://github.com/bucketplace/ohouse-auth/pull/169/files) 