### PR TITLE
[COREPL-1565] `Web Checks` 워크플로우에서 memory limit이 cgroup-aware하도록 수정

### DIFF
--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Calculate available system memory for heap allocation
         id: calc-system-memory
         shell: bash
-        run: echo "available=$(expr $(echo "$(free -m)" | awk '/^Mem:/ {print $2}') - 512)" >> $GITHUB_OUTPUT
+        run: echo "available=$(expr $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1024 / 1024 / 100 \* 75)" >> $GITHUB_OUTPUT
       - name: Check whether prepare script is present
         id: check-test-configured
         shell: bash

--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Calculate available system memory for heap allocation
         id: calc-system-memory
         shell: bash
-        run: echo "available=$(expr $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1024 / 1024 / 100 \* 75)" >> $GITHUB_OUTPUT
+        run: echo "available=$(expr $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1024 / 1024 / 100 \* 50)" >> $GITHUB_OUTPUT
       - name: Check whether prepare script is present
         id: check-test-configured
         shell: bash


### PR DESCRIPTION
## Proposed Changes
- `Web Checks` 워크플로우에서 memory limit이 cgroup-aware하도록 수정합니다.
- 가용 메모리의 75%만 사용합니다.

## Test Status
https://github.com/bucketplace/ohou.se-client/actions/runs/7334826721/job/19971982908 실패하는 액션에서 테스트하여 성공하는지 확인합니다.
