### PR TITLE
[SEARCH-2424] release 태그 추출시 이상한 태그 들어오는 버그 수정

### DIFF
--- a/.github/actions/latest-tag-finder/action.yml
+++ b/.github/actions/latest-tag-finder/action.yml
@@ -50,7 +50,7 @@ runs:
       id: current-tag  # The step ID to refer to later.
       run: |
         cd __temp__99
-        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | grep '^${{ inputs.prefix }}[0-9]' |sort --version-sort -r | head -n 1 | tr -d '[:space:]')
+        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | grep -E '^${{ inputs.prefix }}[0-9]+\.[0-9]+\.[0-9]+&' |sort --version-sort -r | head -n 1 | tr -d '[:space:]')
         echo "version=${LATEST_TAG#${{ inputs.prefix }}}" >> $GITHUB_OUTPUT
         echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
         rm -rf __temp__99

--- a/.github/actions/latest-tag-finder/action.yml
+++ b/.github/actions/latest-tag-finder/action.yml
@@ -50,7 +50,7 @@ runs:
       id: current-tag  # The step ID to refer to later.
       run: |
         cd __temp__99
-        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | grep '^${{ inputs.prefix }}-[0-9]' |sort --version-sort -r | head -n 1 | tr -d '[:space:]')
+        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | grep '^${{ inputs.prefix }}[0-9]' |sort --version-sort -r | head -n 1 | tr -d '[:space:]')
         echo "version=${LATEST_TAG#${{ inputs.prefix }}}" >> $GITHUB_OUTPUT
         echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
         rm -rf __temp__99

--- a/.github/actions/latest-tag-finder/action.yml
+++ b/.github/actions/latest-tag-finder/action.yml
@@ -50,7 +50,7 @@ runs:
       id: current-tag  # The step ID to refer to later.
       run: |
         cd __temp__99
-        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | sort --version-sort -r | head -n 1 | tr -d '[:space:]')
+        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | grep '^${{ inputs.prefix }}-[0-9]' |sort --version-sort -r | head -n 1 | tr -d '[:space:]')
         echo "version=${LATEST_TAG#${{ inputs.prefix }}}" >> $GITHUB_OUTPUT
         echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
         rm -rf __temp__99

--- a/.github/actions/latest-tag-finder/action.yml
+++ b/.github/actions/latest-tag-finder/action.yml
@@ -50,7 +50,7 @@ runs:
       id: current-tag  # The step ID to refer to later.
       run: |
         cd __temp__99
-        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | grep -E '^${{ inputs.prefix }}[0-9]+\.[0-9]+\.[0-9]+&' |sort --version-sort -r | head -n 1 | tr -d '[:space:]')
+        LATEST_TAG=$(git tag -l "${{ inputs.prefix }}*" --merged | grep -E '^${{ inputs.prefix }}[0-9]+\.[0-9]+\.[0-9]+$' |sort --version-sort -r | head -n 1 | tr -d '[:space:]')
         echo "version=${LATEST_TAG#${{ inputs.prefix }}}" >> $GITHUB_OUTPUT
         echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
         rm -rf __temp__99


### PR DESCRIPTION
## Proposed Changes
- search-backend repository에서는 search-application-server, search-application-server-global 이라는 두앱이 존재합니다.
- 그래서 search-applciation-server-global-0.0.1, search-application-server-0.0.1 등의 태그가 공존하게됩니다.
- 그래서 search-application-server 기준으로 태그를 가져오면 search-application-server-global의 태그가 잡히게 됩니다.
- 이러한 현상을 제거하기위해서 LATEST_TAG를 가져올 때 prefix 뒤에 바로 version만 있는 태그들만 가져올 수 있도록 수정을 제안합니다.


## Test Status
(테스트를 어떻게 진행했는지 설명합니다.)
