### PR TITLE
[SEARCH-2072] add ingress host key parameter

### DIFF
--- a/.github/workflows/mortar-preview-action.yaml
+++ b/.github/workflows/mortar-preview-action.yaml
@@ -32,6 +32,11 @@ on:
         description: "mortar 버전 (JVM 17이상시 v2, 이하시 v1)"
         required: false
         default: "v2"
+      ingress-host-key:
+        type: string
+        description: "ingress host key"
+        required: false
+        default: "ingress.hosts[0].host"
 
 jobs:
   check-comment:
@@ -183,6 +188,7 @@ jobs:
           pr-url: ${{ needs.get-metadata.outputs.pr_url }}
           pr-assignee: ${{ needs.get-metadata.outputs.pr_assignee }}
           profile: ${{ inputs.profile }}
+          ingress-host-key: ${{ inputs.ingress-host-key }}
           image-tag: ${{ needs.build-and-push.outputs.version }}
           base-domain: ${{ inputs.base-domain }}
           destination: ${{ inputs.destination }}

--- a/.github/workflows/mortar-preview-action.yaml
+++ b/.github/workflows/mortar-preview-action.yaml
@@ -34,7 +34,7 @@ on:
         default: "v2"
       ingress-host-key:
         type: string
-        description: "ingress host key"
+        description: "ingress host key (국내에서는 ingress.hosts[0].host, 글로벌에서는 httpProxy.host)"
         required: false
         default: "ingress.hosts[0].host"
 


### PR DESCRIPTION
## Proposed Changes
- global에서 ingress host를 httpProxy.host값을 사용하고 있습니다. 
- 그래서 global지원을 위해 파라미터로 추가합니다.
- korea에서는 httpProxy.host가 아닌 기본값을 사용해야하는데, 기본값은 https://github.com/bucketplace/ops-monster-v2/blob/99200770f5ba5b249f531e0e16fe22d3aa691600/opsmonster/application/serializers.py#L586 여기에서 확인했습니다. 


## Test Status
(테스트를 어떻게 진행했는지 설명합니다.)
