### PR TITLE
[SC-635] FE Node.js 셋업 액션 추가

### DIFF
--- a/.github/actions/select-nodejs-pkg-manager/action.yml
+++ b/.github/actions/select-nodejs-pkg-manager/action.yml
@@ -5,13 +5,11 @@ inputs:
   app-path:
     description: "Specifies a base directory to run the task from"
     required: false
-    default: '.'
-    type: string
+    default: "."
   package-manager:
     description: "Specifies which package manager to use"
     required: false
     default: ""
-    type: string
 
 outputs:
   bin:

--- a/.github/actions/setup-nodejs/action.yaml
+++ b/.github/actions/setup-nodejs/action.yaml
@@ -1,0 +1,28 @@
+name: "Setup Node.js"
+description: "Setup Node.js and a package manager for the project (See: https://www.notion.so/ohouse/Node-js-GitHub-Actions-b20b90da32e7444591f89b8a2274456c)"
+
+inputs:
+  nodejs-version:
+    description: "Specifies which Node.js version to use"
+    required: false
+    default: "18"
+  registry-url:
+    description: "Specifies the registry URL in which the package manager looks up for packages and publishes to"
+    required: false
+    default: "nexus.co-workerhou.se/repository/npm-private"
+
+runs:
+  using: composite
+  steps:
+    - name: Use Node.js v${{ inputs.nodejs-version }}
+      shell: bash
+      run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+    - name: Configure registry
+      shell: bash
+      if: ${{ env.NPM_TOKEN != '' }}
+      run: |
+        cat <<EOF > "$HOME/.npmrc"
+          //${{ inputs.registry-url }}/:_authToken=$NPM_TOKEN
+        EOF
+      env:
+        NPM_TOKEN: ${{ env.NPM_TOKEN }}

--- a/.github/actions/setup-nodejs/action.yaml
+++ b/.github/actions/setup-nodejs/action.yaml
@@ -16,7 +16,9 @@ runs:
   steps:
     - name: Use Node.js v${{ inputs.nodejs-version }}
       shell: bash
-      run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
+      run: |
+        echo Using Node.js v${{ inputs.nodejs-version }}
+        echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
     - name: Configure registry
       shell: bash
       if: ${{ env.NPM_TOKEN != '' }}

--- a/.github/workflows/check-nodejs.yml
+++ b/.github/workflows/check-nodejs.yml
@@ -43,9 +43,13 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Use Node.js ${{ inputs.nodejs-version }}
-        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
-      - name: Determine which package manager to use
+      - name: Setup Node.js
+        uses: bucketplace/ci/.github/actions/setup-nodejs@latest
+        with:
+          nodejs-version: ${{ inputs.nodejs-version }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Determine package manager
         id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:

--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -75,9 +75,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Use Node.js v${{ inputs.nodejs-version }}
-        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
-      - name: Determine which package manager to use
+      - name: Setup Node.js
+        uses: bucketplace/ci/.github/actions/setup-nodejs@latest
+        with:
+          nodejs-version: ${{ inputs.nodejs-version }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Determine package manager
         id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:

--- a/.github/workflows/reusable-changesets-prerelease.yml
+++ b/.github/workflows/reusable-changesets-prerelease.yml
@@ -47,19 +47,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Use Node.js ${{ inputs.nodejs-version }}
-        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
-      - name: Configure registry
-        run: |
-          cat <<EOF > "$HOME/.npmrc"
-            //nexus.co-workerhou.se/repository/npm-private/:_authToken=$NPM_TOKEN
-          EOF
+      - name: Setup Node.js
+        uses: bucketplace/ci/.github/actions/setup-nodejs@latest
+        with:
+          nodejs-version: ${{ inputs.nodejs-version }}
         env:
-          NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
-      - name: Determine which package manager to use
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Determine package manager
         id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
+          app-path: ${{ inputs.app-path }}
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
         run: ${{ steps.pkg-manager.outputs.install-cmd }}

--- a/.github/workflows/reusable-changesets-publish.yml
+++ b/.github/workflows/reusable-changesets-publish.yml
@@ -41,19 +41,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Use Node.js ${{ inputs.nodejs-version }}
-        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
-      - name: Configure registry
-        run: |
-          cat <<EOF > "$HOME/.npmrc"
-            //nexus.co-workerhou.se/repository/npm-private/:_authToken=$NPM_TOKEN
-          EOF
+      - name: Setup Node.js
+        uses: bucketplace/ci/.github/actions/setup-nodejs@latest
+        with:
+          nodejs-version: ${{ inputs.nodejs-version }}
         env:
-          NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
-      - name: Determine which package manager to use
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Determine package manager
         id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
+          app-path: ${{ inputs.app-path }}
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
         run: ${{ steps.pkg-manager.outputs.install-cmd }}

--- a/.github/workflows/reusable-changesets-snapshot.yml
+++ b/.github/workflows/reusable-changesets-snapshot.yml
@@ -60,19 +60,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }}
-      - name: Use Node.js ${{ inputs.nodejs-version }}
-        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
-      - name: Configure registry
-        run: |
-          cat <<EOF > "$HOME/.npmrc"
-            //nexus.co-workerhou.se/repository/npm-private/:_authToken=$NPM_TOKEN
-          EOF
+      - name: Setup Node.js
+        uses: bucketplace/ci/.github/actions/setup-nodejs@latest
+        with:
+          nodejs-version: ${{ inputs.nodejs-version }}
         env:
-          NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
-      - name: Determine which package manager to use
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Determine package manager
         id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:
+          app-path: ${{ inputs.app-path }}
           package-manager: ${{ inputs.package-manager }}
       - name: Install dependencies
         run: ${{ steps.pkg-manager.outputs.install-cmd }}

--- a/.github/workflows/reusable-sonarcloud-analysis-nodejs.yml
+++ b/.github/workflows/reusable-sonarcloud-analysis-nodejs.yml
@@ -59,9 +59,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Use Node.js ${{ inputs.nodejs-version }}
-        run: echo ${{ inputs.nodejs-version }} > .nvmrc && nvm use
-      - name: Determine which package manager to use
+      - name: Setup Node.js
+        uses: bucketplace/ci/.github/actions/setup-nodejs@latest
+        with:
+          nodejs-version: ${{ inputs.nodejs-version }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Determine package manager
         id: pkg-manager
         uses: bucketplace/ci/.github/actions/select-nodejs-pkg-manager@latest
         with:


### PR DESCRIPTION
## Proposed Changes
- Self-hosted runner와 함께 사용하는 것을 가정하는 FE Node.js 셋업 액션을 추가합니다.
- 다른 액션과 조합하여 워크플로우를 구성할 수 있도록 합니다.
- 추후 모든 Node.js 프로젝트에 적용되어야 하는 pre-condition (공용 글로벌 CLI 도구 설치 등)을 본 액션에서 처리합니다.
- 올바르지 않은 필드를 기존 CI 설정에서 제거합니다.
- 기존 CI 워크플로우를 업데이트합니다.

## Test Status
~~`ohouse-divops`에서 테스트를 진행합니다.~~ 액션의 경우 저장소에서 재사용 워크플로우에서 참조시 바로 테스트가 어려워서 병합 후 rc로 테스트를 진행합니다.
